### PR TITLE
feat: added NR06 italian on BibleVersionCollection

### DIFF
--- a/src/data/BibleVersionCollection.ts
+++ b/src/data/BibleVersionCollection.ts
@@ -104,7 +104,7 @@ export const BibleVersionCollection: IBibleVersion[] = [
     apiSource: BibleAPISourceCollection.bollsLife,
   },
   {
-    key: 'NR06',
+    key: 'nr06',
     versionName: 'Nuova Riveduta, 2006',
     language: 'Latin / Italian',
     apiSource: BibleAPISourceCollection.bollsLife,

--- a/src/data/BibleVersionCollection.ts
+++ b/src/data/BibleVersionCollection.ts
@@ -103,4 +103,10 @@ export const BibleVersionCollection: IBibleVersion[] = [
     language: 'Chinese',
     apiSource: BibleAPISourceCollection.bollsLife,
   },
+  {
+    key: 'NR06',
+    versionName: 'Nuova Riveduta, 2006',
+    language: 'Latin / Italian',
+    apiSource: BibleAPISourceCollection.bollsLife,
+  },
 ]


### PR DESCRIPTION
Hi there,

I recently came across your plugin for Obsidian on GitHub and noticed that it didn't have support for Italian language. As an Italian speaker, I wanted to contribute to the project and make it more accessible to Italian users.

So, for now I added support for Italian language with the Italian version of the "Nuova Riveduta06" Bible.  In the future, I plan to work on mapping the names of the books and their abbreviations in Italian as well.

I have created a pull request for the changes that I have made. I would greatly appreciate it if you could take a look at it and merge it into the main branch if everything looks good to you. 

Thank you for your time and for creating such a useful plugin for the Obsidian community.

Best regards,
Simone