### PR TITLE
Feature/callout link to bible app

### DIFF
--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -147,7 +147,7 @@ export class VerseSuggesting implements IVerseSuggesting {
   public getVerseReference(): string {
     return ` [${
       this.bibleProvider.BibleReferenceHead
-    } - ${this.bibleVersion.toUpperCase()}](${this.bibleProvider.QueryURL})`
+    } - ${this.bibleVersion.toUpperCase()}](${this.bibleProvider.VerseLinkURL})`
   }
 
   /**

--- a/src/provider/BibleProvider.ts
+++ b/src/provider/BibleProvider.ts
@@ -18,7 +18,16 @@ export abstract class BibleProvider {
    * for example, https://api.scripture.api.bible/v1/bibles/de4e0c8c-9c29-44c7-a8c3-c8a9c1b9d6a0/verses/ESV/
    */
   public get QueryURL(): string {
-    return this._queryUrl
+    return this._queryUrl;
+  }
+
+  /**
+   * Get the Callout Link URL for the verse query
+   * By default it's the Query URL, but for some API there is a provided web app, so it will link to that.
+   * In the Bolly Life interface, it's just the same URL location except without `/get-text`
+   */
+  public get VerseLinkURL(): string {
+    return this._queryUrl;
   }
 
   /**

--- a/src/provider/BollyLifeProvider.ts
+++ b/src/provider/BollyLifeProvider.ts
@@ -17,6 +17,10 @@ export class BollyLifeProvider extends BibleProvider {
     this._chapterApiUrl = this._apiUrl
   }
 
+  public get QueryURL(): string {
+    return this._queryUrl.replace("/get-text", "");
+  }
+
   public buildRequestURL(
     bookName: string,
     chapter: number,

--- a/src/provider/BollyLifeProvider.ts
+++ b/src/provider/BollyLifeProvider.ts
@@ -17,7 +17,7 @@ export class BollyLifeProvider extends BibleProvider {
     this._chapterApiUrl = this._apiUrl
   }
 
-  public get QueryURL(): string {
+  public get VerseLinkURL(): string {
     return this._queryUrl.replace("/get-text", "");
   }
 


### PR DESCRIPTION
So this change only works for the Bolly Life API since it provides a web page with the book and chapter. Detailed in issue #84  

I extended the interface of the Bible Provider to separate `QueryURL` from `VerseLinkURL` in case there's a use for the `QueryURL`. 

Apologies if you wanted me to add testing, could do as desired. :)