### PR TITLE
Tagging and Backlinks

### DIFF
--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -58,6 +58,22 @@ export class VerseSuggesting implements IVerseSuggesting {
     ) {
       bottom += `> \n ${this.getVerseReference()}`
     }
+    if (
+      this.settings?.bibleTagging ||
+      this.settings?.bookTagging ||
+      this.settings?.chapterTagging) {
+      bottom += ' %%'
+      bottom += (this.settings?.bibleTagging) ? ' #bible' : ''
+      bottom += (this.settings?.bookTagging) ? ` #${this.bookName}` : ''
+      bottom += (this.settings?.chapterTagging) ? ` #${this.bookName}_${this.chapterNumber}` : ''
+      bottom += ' %%'
+    }
+    if (this.settings?.bookBacklinking){
+      bottom += ` [[${this.bookName}]]`
+    }
+    if (this.settings?.chapterBacklinking){
+      bottom += ` [[${this.bookName}_${this.chapterNumber}]]`
+    }
     return [head, this.text, bottom].join('\n')
   }
 

--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -11,6 +11,7 @@ import { BibleProvider } from './provider/BibleProvider'
 import { BibleVerseReferenceLinkPosition } from './data/BibleVerseReferenceLinkPosition'
 import { BibleVerseNumberFormat } from './data/BibleVerseNumberFormat'
 import { BibleVerseFormat } from './data/BibleVerseFormat'
+import { BOOK_REG, Book_REG } from './utils/regs'
 
 export class VerseSuggesting implements IVerseSuggesting {
   public text: string
@@ -58,22 +59,27 @@ export class VerseSuggesting implements IVerseSuggesting {
     ) {
       bottom += `> \n ${this.getVerseReference()}`
     }
+
+    // backlinks and tags use the BibleReferenceHeader 
+    //  and regex to clean book and chapters that will match
+    //  across multiple different search queires
+    if (this.settings?.bookBacklinking){
+      head += ` [[${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}/)![0].replace(/\s+/g, '')}]]`
+    }
+    if (this.settings?.chapterBacklinking){
+      head += ` [[${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}[ ]*[0-9]*/)![0].replace(/\s+/g, '')}]]`
+    }
     if (
       this.settings?.bibleTagging ||
       this.settings?.bookTagging ||
       this.settings?.chapterTagging) {
       bottom += ' %%'
       bottom += (this.settings?.bibleTagging) ? ' #bible' : ''
-      bottom += (this.settings?.bookTagging) ? ` #${this.bookName}` : ''
-      bottom += (this.settings?.chapterTagging) ? ` #${this.bookName}_${this.chapterNumber}` : ''
+      bottom += (this.settings?.bookTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}/)![0].replace(/\s+/g, '')}` : ''
+      bottom += (this.settings?.chapterTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}[ ]*[0-9]*/)![0].replace(/\s+/g, '')}` : ''
       bottom += ' %%'
     }
-    if (this.settings?.bookBacklinking){
-      bottom += ` [[${this.bookName}]]`
-    }
-    if (this.settings?.chapterBacklinking){
-      bottom += ` [[${this.bookName}_${this.chapterNumber}]]`
-    }
+
     return [head, this.text, bottom].join('\n')
   }
 

--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -11,7 +11,6 @@ import { BibleProvider } from './provider/BibleProvider'
 import { BibleVerseReferenceLinkPosition } from './data/BibleVerseReferenceLinkPosition'
 import { BibleVerseNumberFormat } from './data/BibleVerseNumberFormat'
 import { BibleVerseFormat } from './data/BibleVerseFormat'
-import { BOOK_REG, Book_REG } from './utils/regs'
 
 export class VerseSuggesting implements IVerseSuggesting {
   public text: string
@@ -64,10 +63,10 @@ export class VerseSuggesting implements IVerseSuggesting {
     //  and regex to clean book and chapters that will match
     //  across multiple different search queires
     if (this.settings?.bookBacklinking){
-      head += ` [[${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}/)![0].replace(/\s+/g, '')}]]`
+      head += ` [[${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}/)![0].replace(/\s+/g, '').toLowerCase()}]]`
     }
     if (this.settings?.chapterBacklinking){
-      head += ` [[${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}[ ]*[0-9]*/)![0].replace(/\s+/g, '')}]]`
+      head += ` [[${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}[ ]*[0-9]*/)![0].replace(/\s+/g, '').toLowerCase()}]]`
     }
     if (
       this.settings?.bibleTagging ||
@@ -75,8 +74,8 @@ export class VerseSuggesting implements IVerseSuggesting {
       this.settings?.chapterTagging) {
       bottom += ' %%'
       bottom += (this.settings?.bibleTagging) ? ' #bible' : ''
-      bottom += (this.settings?.bookTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}/)![0].replace(/\s+/g, '')}` : ''
-      bottom += (this.settings?.chapterTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}[ ]*[0-9]*/)![0].replace(/\s+/g, '')}` : ''
+      bottom += (this.settings?.bookTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}/)![0].replace(/\s+/g, '').toLowerCase()}` : ''
+      bottom += (this.settings?.chapterTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(/[123]*[ ]*[A-z]{3,}[ ]*[0-9]*/)![0].replace(/\s+/g, '').toLowerCase()}` : ''
       bottom += ' %%'
     }
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -16,6 +16,11 @@ export interface BibleReferencePluginSettings {
   verseFormatting?: BibleVerseFormat
   verseNumberFormatting?: BibleVerseNumberFormat
   collapsibleVerses?: boolean
+  bibleTagging?: boolean
+  bookTagging?: boolean
+  chapterTagging?: boolean
+  bookBacklinking?: boolean
+  chapterBacklinking?: boolean
 }
 
 export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
@@ -24,4 +29,9 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   verseFormatting: BibleVerseFormat.SingleLine,
   verseNumberFormatting: BibleVerseNumberFormat.Period,
   collapsibleVerses: false,
+  bibleTagging: false,
+  bookTagging: false,
+  chapterTagging: false,
+  bookBacklinking: false,
+  chapterBacklinking: false,
 }

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -154,6 +154,76 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
       )
   }
 
+  SetUpBibleTagging = (containerEl: HTMLElement): void => {
+    new Setting(containerEl)
+      .setName('Create Bible Tags')
+      .setDesc('Makes hidden #bible tag')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(!!this.plugin.settings?.bibleTagging)
+          .onChange((value) => {
+            this.plugin.settings.bibleTagging = value
+            this.plugin.saveData(this.plugin.settings)
+          })
+      )
+  }
+
+  SetUpBookTagging = (containerEl: HTMLElement): void => {
+    new Setting(containerEl)
+      .setName('Create Book Tags')
+      .setDesc('Makes hidden #{book} tag')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(!!this.plugin.settings?.bookTagging)
+          .onChange((value) => {
+            this.plugin.settings.bookTagging = value
+            this.plugin.saveData(this.plugin.settings)
+          })
+      )
+  }
+
+  SetUpChapterTagging = (containerEl: HTMLElement): void => {
+    new Setting(containerEl)
+      .setName('Create Chapter Tags')
+      .setDesc('Makes hidden #{book_chapter} tag')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(!!this.plugin.settings?.chapterTagging)
+          .onChange((value) => {
+            this.plugin.settings.chapterTagging = value
+            this.plugin.saveData(this.plugin.settings)
+          })
+      )
+  }
+
+  SetUpBookBacklinking = (containerEl: HTMLElement): void => {
+    new Setting(containerEl)
+      .setName('Create Book Backlink')
+      .setDesc('Makes [[{book}]] link')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(!!this.plugin.settings?.bookBacklinking)
+          .onChange((value) => {
+            this.plugin.settings.bookBacklinking = value
+            this.plugin.saveData(this.plugin.settings)
+          })
+      )
+  }
+
+  SetUpChapterBacklinking = (containerEl: HTMLElement): void => {
+    new Setting(containerEl)
+      .setName('Create Chapter Tags')
+      .setDesc('Makes [[{book_chapter}]] link')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(!!this.plugin.settings?.chapterBacklinking)
+          .onChange((value) => {
+            this.plugin.settings.chapterBacklinking = value
+            this.plugin.saveData(this.plugin.settings)
+          })
+      )
+  }
+
   display(): void {
     const { containerEl } = this
     containerEl.empty()
@@ -162,12 +232,18 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
         <iframe src="https://github.com/sponsors/tim-hub/button" title="Sponsor Obsidian Bible Reference" width="116" height="32px" style="margin-right: 2em"/>
     `
 
-    containerEl.createEl('h2', { text: 'Settings' })
+    containerEl.createEl('h2', { text: 'General Settings' })
     this.SetUpVersionSettingsAndVersionOptions(containerEl)
     this.SetUpReferenceLinkPositionOptions(containerEl)
     this.SetUpVerseFormatOptions(containerEl)
     this.SetUpVerseNumberFormatOptions(containerEl)
     this.SetUpTextOptions(containerEl)
+    containerEl.createEl('h2', { text: 'Tagging and Linking Settings' })
+    this.SetUpBibleTagging(containerEl)
+    this.SetUpBookTagging(containerEl)
+    this.SetUpChapterTagging(containerEl)
+    this.SetUpBookBacklinking(containerEl)
+    this.SetUpChapterBacklinking(containerEl)
 
     containerEl.createEl('h2', { text: 'About' })
 


### PR DESCRIPTION
Issues: #95 #81

# Overview of solution
Based on the suggestions from the comments in #81, I created hidden tags as @tim-hub had [suggested in the thread](https://github.com/tim-hub/obsidian-bible-reference/issues/81#issuecomment-1440687871). I found that based on the discussion there is a difficult decision on where exactly to create the tag or backlink (at the book, chapter, or verse level). Because tagging at a verse level would be very difficult and likely require a different view (as suggested by @Bill77  in [their comment on the thread](https://github.com/tim-hub/obsidian-bible-reference/issues/81#issuecomment-1455401479)) I have set tags to be allowed at 3 levels all placed in the bottom of the text.
1. Global `#bible` tag that would let you see all notes that contain bible verses
2. Book `#{book}` tag
3. Chapter `#{book}{chapter}` tag

These three levels are each individually optional within the settings (and I have labeled this new set of settings accordingly as "Tags and Linking Settings" and the previous settings as "General Settings")

Because I don't see much want from the community to have a single note that functions like the global tag, the two options for backlinks are:
1. Book `[[{book}]]` backlink
2. Chapter `[[{book}{chapter}]]` backlink

Backlinks are placed in the head of the text (which seems to make the most sense, but this could be changed to have a similar drop box option for the location as the referenceLinkPosition)

The regex used to create the book and chapter names that should be consistent within English and other Romanized languages. And it appeared that the CUV (Chinese Union Version) and Arabic versions currently available use English book names, so this will still work with those versions (assuming the English book names are maintained).

# Example Output
All options turned on:
- reference shown at top and bottom
- all tags turned on (global, book, chapter)
- all backlinks turned on (book, chapter)

> [!Bible] [john 1:1 - ESV](https://bolls.life/ESV/43/1/) [[john]] [[john1]]
> <sup> 1 </sup>In the beginning was the Word, and the Word was with God, and the Word was God.
> 
  [john 1:1 - ESV](https://bolls.life/ESV/43/1/) %% #bible #john #john1 %%

![image](https://github.com/tim-hub/obsidian-bible-reference/assets/22432499/115eb4e4-cbd6-40d7-acd6-31328c255413)
---
The following options:
- reference shown at the bottom
- book and chapter tags turned on
- only book backlink turned on

> [!Bible] [[1peter]]
> <sup> 15 </sup>but in your hearts honor Christ the Lord as holy, always being prepared to make a defense to anyone who asks you for a reason for the hope that is in you; yet do it with gentleness and respect,
> <sup> 16 </sup>having a good conscience, so that, when you are slandered, those who revile your good behavior in Christ may be put to shame.
> 
  [1peter 3:15-16 - ESV](https://bolls.life/ESV/60/3/) %% #1peter #1peter3 %%

![image](https://github.com/tim-hub/obsidian-bible-reference/assets/22432499/382582c1-6a81-4ad3-95a0-6b149ffca293)
---
And here is a screenshot of the final settings

![image](https://github.com/tim-hub/obsidian-bible-reference/assets/22432499/c75f18c6-0525-4a2f-8d5e-74c2c1603a43)


  
  