### PR TITLE
(bolls life API) Fixed book formatting when book name starts with a number

### DIFF
--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -173,7 +173,7 @@ export class VerseSuggesting implements IVerseSuggesting {
     let bibleReferenceTitle = this.bibleProvider.BibleReferenceHead;
 
     // The bolls life API returns the book name without any spaces - that doesn't look right.
-    if(bibleReferenceTitle.match('^[0-9]\s.*')) {
+    if(bibleReferenceTitle.match('^[0-9][A-Za-z].*')) {
       bibleReferenceTitle = bibleReferenceTitle[0] + " " + bibleReferenceTitle.slice(1)
     }
     

--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -170,8 +170,15 @@ export class VerseSuggesting implements IVerseSuggesting {
   }
 
   public getVerseReference(): string {
+    let bibleReferenceTitle = this.bibleProvider.BibleReferenceHead;
+
+    // The bolls life API returns the book name without any spaces - that doesn't look right.
+    if(bibleReferenceTitle.match('^[0-9]\S.*')) {
+      bibleReferenceTitle = bibleReferenceTitle[0] + " " + bibleReferenceTitle.slice(1)
+    }
+    
     return ` [${
-      this.bibleProvider.BibleReferenceHead
+      bibleReferenceTitle
     } - ${this.bibleVersion.toUpperCase()}](${this.bibleProvider.VerseLinkURL})`
   }
 

--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -173,7 +173,7 @@ export class VerseSuggesting implements IVerseSuggesting {
     let bibleReferenceTitle = this.bibleProvider.BibleReferenceHead;
 
     // The bolls life API returns the book name without any spaces - that doesn't look right.
-    if(bibleReferenceTitle.match('^[0-9]\S.*')) {
+    if(bibleReferenceTitle.match('^[0-9]\s.*')) {
       bibleReferenceTitle = bibleReferenceTitle[0] + " " + bibleReferenceTitle.slice(1)
     }
     


### PR DESCRIPTION
I have been using the NKJV version from bolls life API, and it returns the link text for books such as `2 Corinthians` as `2Corinthians`.  This PR fixes the formatting when displayed to the user.

Unsure of better places to fix this - I may be missing a part of the picture in how this plugin accepts data from these APIs.