### PR TITLE
Created common book names

### DIFF
--- a/src/VerseSuggesting.ts
+++ b/src/VerseSuggesting.ts
@@ -12,9 +12,6 @@ import { BibleVerseReferenceLinkPosition } from './data/BibleVerseReferenceLinkP
 import { BibleVerseNumberFormat } from './data/BibleVerseNumberFormat'
 import { BibleVerseFormat } from './data/BibleVerseFormat'
 
-const BOOK_REGEX = /[123]*[ ]*[a-zA-Z]{3,}/
-const CHAPTER_REGEX = /[123]*[ ]*[a-zA-Z]{3,}[ ]*[0-9]*/
-
 
 export class VerseSuggesting implements IVerseSuggesting {
   public text: string
@@ -67,10 +64,10 @@ export class VerseSuggesting implements IVerseSuggesting {
     //  and regex to clean book and chapters that will match
     //  across multiple different search queires
     if (this.settings?.bookBacklinking){
-      head += ` [[${this.bibleProvider.BibleReferenceHead.match(BOOK_REGEX)![0].replace(/\s+/g, '').toLowerCase()}]]`
+      head += ` [[${this.bookName}]]`
     }
     if (this.settings?.chapterBacklinking){
-      head += ` [[${this.bibleProvider.BibleReferenceHead.match(CHAPTER_REGEX)![0].replace(/\s+/g, '').toLowerCase()}]]`
+      head += ` [[${this.bookName+this.chapterNumber}]]`
     }
     if (
       this.settings?.bibleTagging ||
@@ -78,8 +75,8 @@ export class VerseSuggesting implements IVerseSuggesting {
       this.settings?.chapterTagging) {
       bottom += ' %%'
       bottom += (this.settings?.bibleTagging) ? ' #bible' : ''
-      bottom += (this.settings?.bookTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(BOOK_REGEX)![0].replace(/\s+/g, '').toLowerCase()}` : ''
-      bottom += (this.settings?.chapterTagging) ? ` #${this.bibleProvider.BibleReferenceHead.match(CHAPTER_REGEX)![0].replace(/\s+/g, '').toLowerCase()}` : ''
+      bottom += (this.settings?.bookTagging) ? ` #${this.bookName}` : ''
+      bottom += (this.settings?.chapterTagging) ? ` #${this.bookName+this.chapterNumber}` : ''
       bottom += ' %%'
     }
 

--- a/src/suggesetor/getSuggestionsFromQuery.ts
+++ b/src/suggesetor/getSuggestionsFromQuery.ts
@@ -1,6 +1,7 @@
 import { BibleReferencePluginSettings } from '../data/constants'
 import { VerseSuggesting } from '../VerseSuggesting'
 import { BOOK_REG } from '../utils/regs'
+import { Reference } from '../../biblejs-name-converter'
 
 /**
  * Get suggestions from string query
@@ -11,19 +12,22 @@ export async function getSuggestionsFromQuery(
 ): Promise<VerseSuggesting[]> {
   console.debug('get suggestion for query ', query.toLowerCase())
 
-  const bookName = query.match(BOOK_REG)?.first()
-
-  if (!bookName) {
+  const rawBookName = query.match(BOOK_REG)?.first()
+  
+  if (!rawBookName) {
     console.error(`could not find through query`, query)
     return []
   }
 
-  const numbersPartsOfQueryString = query.substring(2 + bookName.length)
+  const numbersPartsOfQueryString = query.substring(2 + rawBookName.length)
   const numbers = numbersPartsOfQueryString.split(/[-:]+/)
 
-  const chapterNumber = parseInt(numbers[0])
+  const chapterNumber = parseInt(numbers[0].trim())
   const verseNumber = parseInt(numbers[1])
   const verseEndNumber = numbers.length === 3 ? parseInt(numbers[2]) : undefined
+
+  const bookId = Reference.bookIdFromName(rawBookName)
+  const bookName = Reference.bookNameFromId(bookId)
 
   // todo get bibleVersion and language from settings
   const suggestingVerse = new VerseSuggesting(

--- a/src/utils/regs.ts
+++ b/src/utils/regs.ts
@@ -13,13 +13,13 @@ export const ORIGINAL_REG = /-{2}(([123])*)(\w{3,})\+\d{0,3}:*\d{0,3}-*\d{0,3}$/
  * --John12:1-3
  * --John1:1
  */
-export const SHORT_REG = /-{2}([123])*[A-z]{3,}\d{1,3}:\d{1,3}(-\d{1,3})*/
+export const SHORT_REG = /-{2}([123])*\s*[A-z]{3,}\s*\d{1,3}:\d{1,3}(-\d{1,3})*/
 
 /**
  * regular expression to match
  * John12:1-3
  * John1:1
  */
-export const MODAL_REG = /([123])*[A-z]{3,}\d{1,3}:\d{1,3}(-\d{1,3})*/
+export const MODAL_REG = /([123])*\s*[A-z]{3,}\s*\d{1,3}:\d{1,3}(-\d{1,3})*/
 
-export const BOOK_REG = /[123]*[A-z]{3,}/
+export const BOOK_REG = /[123]*\s*[A-z]{3,}/


### PR DESCRIPTION
# Overview
In PR #96 the addition of tags and backlinks becomes problematic due to the inconsistent nature of the book names. For example we can reference Genesis 1:1 using the queries - "genesis1:1" and "gen1:1". This would create 2 different sets of tags and links (see following image). Note that I will be keeping all backlinks and tags turned on for all screenshots shown with the ESV version.
![image](https://github.com/tim-hub/obsidian-bible-reference/assets/22432499/06ca0aaa-313f-4f01-8f25-1aa6646a2e10)


# Solution
## Design
Book names are set to a standard name at the initial parsing of the query using the biblejs-name-converter. This was previously just called later in the data pipeline for the bolly bible provider, but by moving it to the beginning of parsing, it makes the reference head, backlinks, and tags all utilize the same string.

Additionally, spaces can be added to the queries to more accurately allow for bible verses typed more naturally like "gen 1:1"

## Result
We can see the exact same two queries from before "genesis1:1" and "gen1:1" now show us the same links (see following image)
![image](https://github.com/tim-hub/obsidian-bible-reference/assets/22432499/f963b951-185b-45e7-aa35-782264f3550e)

We can also take more complex queries that contain spaces into account, providing for more natural suggestion (see following image)
![image](https://github.com/tim-hub/obsidian-bible-reference/assets/22432499/d38e0232-2191-4208-9fc2-c59c299f0962)

# Final Notes
As noted in the discussion of #95 [here](https://github.com/tim-hub/obsidian-bible-reference/issues/95#issuecomment-1578493664), the additions for users to set the layout of their tags/backlinks could now more easily be included since the bookname and chapter (and even verse) are now easily accessible in [VerseSuggesting.ts](https://github.com/tim-hub/obsidian-bible-reference/blob/master/src/VerseSuggesting.ts). Likely we could start by having a dropdown menu with a few options, and this should be sufficient. I will make note of the suggestion [here](https://github.com/tim-hub/obsidian-bible-reference/issues/95#issuecomment-1573106495) for nested tags, which could be interesting, and might be worth considering (possibly by having different options for tagging formats vs backlink formats).