### PR TITLE
Updated instructions for dependency

### DIFF
--- a/docs/ObsidianPluginDevelopment.md
+++ b/docs/ObsidianPluginDevelopment.md
@@ -7,7 +7,8 @@ Quick starting guide for new plugin devs:
 - Clone your repo to a local development folder. For convenience, you can place this folder in your `.obsidian/plugins/your-plugin-name` folder.
 - Install NodeJS, then run `npm i` in the command line under your repo folder.
 - Run `npm run dev` to compile your plugin from `main.ts` to `main.js`.
-- If you get an error related to `biblejs-name-converter`, go to that file. If it is empty, clone `https://github.com/tim-hub/biblejs-name-converter` into that folder and run `npm i` and `npm run dev` in that folder. 
+  - If you get an error related to `biblejs-name-converter`, go to that file. If it is empty, clone `https://github.com/tim-hub/biblejs-name-converter` into that folder.
+  - Run `npm i` in that folder. 
 - Make changes to `main.ts` (or create new `.ts` files). Those changes should be automatically compiled into `main.js`.
 - Reload Obsidian to load the new version of your plugin.
 - Enable plugin in settings window.

--- a/docs/ObsidianPluginDevelopment.md
+++ b/docs/ObsidianPluginDevelopment.md
@@ -7,6 +7,7 @@ Quick starting guide for new plugin devs:
 - Clone your repo to a local development folder. For convenience, you can place this folder in your `.obsidian/plugins/your-plugin-name` folder.
 - Install NodeJS, then run `npm i` in the command line under your repo folder.
 - Run `npm run dev` to compile your plugin from `main.ts` to `main.js`.
+- If you get an error related to `biblejs-name-converter`, go to that file. If it is empty, clone `https://github.com/tim-hub/biblejs-name-converter` into that folder and run `npm i` and `npm run dev` in that folder. 
 - Make changes to `main.ts` (or create new `.ts` files). Those changes should be automatically compiled into `main.js`.
 - Reload Obsidian to load the new version of your plugin.
 - Enable plugin in settings window.
@@ -24,6 +25,7 @@ Quick starting guide for new plugin devs:
 - Clone this repo.
 - `npm i` or `yarn` to install dependencies
 - `npm run dev` to start compilation in watch mode.
+- If you get an error related to `biblejs-name-converter`, go to that file. If it is empty, clone `https://github.com/tim-hub/biblejs-name-converter` into that folder and run `npm i` and `npm run dev` in that folder. 
 
 ### Manually installing the plugin
 


### PR DESCRIPTION
I wanted to start contributing but ran into an error. When I ran `npm run dev`, I ran into an error with the `biblejs-name-converter` file. I checked the file, and it was completely empty. 

I added instructions to the docs on how to resolve this error. You just need to install the dependency, which doesn't install with the original clone. 

![image](https://github.com/tim-hub/obsidian-bible-reference/assets/88126013/8d8ada9f-5c1e-4ca3-a665-d3904225a5d5)
![image](https://github.com/tim-hub/obsidian-bible-reference/assets/88126013/b0220cac-8bf6-421b-8eeb-c5ff67109014)
