### PR TITLE
Using modals to increase customizability and allowing for different reference styles

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import {
 } from './data/constants'
 import { BibleReferenceSettingTab } from './ui/BibleReferenceSettingTab'
 import { VerseEditorSuggester } from './suggesetor/VerseEditorSuggester'
-import { VerseModalSuggester } from './suggesetor/VerseModalSuggester'
+// import { VerseModalSuggester } from './suggesetor/VerseModalSuggester'
 import { VerseModalSuggesterV2 } from './suggesetor/VersemodalSuggesterV2'
 
 export default class BibleReferencePlugin extends Plugin {
@@ -17,7 +17,7 @@ export default class BibleReferencePlugin extends Plugin {
     console.log('loading plugin -', APP_NAMING.appName)
 
     await this.loadSettings()
-    this.suggestModal = new VerseModalSuggesterV2(this.app, this.settings)
+    this.suggestModal = new VerseModalSuggesterV2(this.app, this.settings, this)
     this.addSettingTab(new BibleReferenceSettingTab(this.app, this))
     this.registerEditorSuggest(new VerseEditorSuggester(this, this.settings))
     this.addCommand({

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,16 +7,17 @@ import {
 import { BibleReferenceSettingTab } from './ui/BibleReferenceSettingTab'
 import { VerseEditorSuggester } from './suggesetor/VerseEditorSuggester'
 import { VerseModalSuggester } from './suggesetor/VerseModalSuggester'
+import { VerseModalSuggesterV2 } from './suggesetor/VersemodalSuggesterV2'
 
 export default class BibleReferencePlugin extends Plugin {
   settings: BibleReferencePluginSettings
-  suggestModal: VerseModalSuggester
+  suggestModal: VerseModalSuggesterV2
 
   async onload() {
     console.log('loading plugin -', APP_NAMING.appName)
 
     await this.loadSettings()
-    this.suggestModal = new VerseModalSuggester(this.app, this.settings)
+    this.suggestModal = new VerseModalSuggesterV2(this.app, this.settings)
     this.addSettingTab(new BibleReferenceSettingTab(this.app, this))
     this.registerEditorSuggest(new VerseEditorSuggester(this, this.settings))
     this.addCommand({

--- a/src/suggesetor/VersemodalSuggesterV2.ts
+++ b/src/suggesetor/VersemodalSuggesterV2.ts
@@ -40,6 +40,7 @@ export class VerseModalSuggesterV2 extends Modal {
     onOpen() {
         this.modalEl.style.width = '40%'
         const { contentEl } = this
+        contentEl.createEl('h3', {text: 'Insert Verse'})
         const settingsInModal = new BibleReferenceSettingTab(this.app, this.plugin)
 
         // Verse Text Box

--- a/src/suggesetor/VersemodalSuggesterV2.ts
+++ b/src/suggesetor/VersemodalSuggesterV2.ts
@@ -1,0 +1,64 @@
+import { App, DropdownComponent, Modal, SuggestModal, TextComponent, ToggleComponent } from "obsidian";
+import { VerseSuggesting } from "src/VerseSuggesting";
+import { BibleVersionCollection } from "src/data/BibleVersionCollection";
+import { BibleReferencePluginSettings } from "src/data/constants";
+import { IBibleVersion } from "src/interfaces/IBibleVersion";
+
+
+export class VerseModalSuggesterV2 extends Modal {
+    settings: BibleReferencePluginSettings
+
+    constructor(app: App, settings: BibleReferencePluginSettings) {
+        super(app)
+        this.settings = settings
+    }
+
+    getAllBibleVersionsWithLanguageNameAlphabetically = (): IBibleVersion[] => {
+        return BibleVersionCollection.sort((a, b) => {
+            // sort by language and versionName alphabetically
+            const languageCompare = a.language.localeCompare(b.language)
+            if (languageCompare === 0) {
+                return a.versionName.localeCompare(b.versionName)
+            } else {
+                return languageCompare
+            }
+        })
+    }
+
+    formatVersionsIntoObject = () => {
+        const allVersionOptions = this.getAllBibleVersionsWithLanguageNameAlphabetically()
+        const obj: {[k: string]: string} = {};
+        
+        allVersionOptions.forEach((version: IBibleVersion) => {
+            obj[version.key] = `${version.language} - ${version.versionName}`
+        })
+        return obj
+    }
+
+    onOpen() {
+        const { contentEl } = this
+
+        const referenceTextBoxDiv = contentEl.createDiv()
+        referenceTextBoxDiv.createEl('div', {text: 'Verse Reference:', cls: 'modal-contents'})
+        new TextComponent (referenceTextBoxDiv)
+            .setPlaceholder('Gen1:1')
+
+        const translationSelecterDiv = contentEl.createDiv()
+        translationSelecterDiv.createEl('div', {text: 'Select Translation:', cls: 'modal-contents'})
+        new DropdownComponent (translationSelecterDiv)
+            .addOptions(this.formatVersionsIntoObject())
+            .setValue(this.settings.bibleVersion)
+
+        const includeTranslationInReferenceDiv = contentEl.createDiv()
+        includeTranslationInReferenceDiv.createEl('div', {text: 'Include Translation in the Reference:', cls: 'modal-contents'})
+        new ToggleComponent (includeTranslationInReferenceDiv)
+            .setValue(false)
+    }
+
+    onClose() {
+        const { contentEl } = this
+        contentEl.empty()
+    }
+    
+
+}

--- a/src/suggesetor/VersemodalSuggesterV2.ts
+++ b/src/suggesetor/VersemodalSuggesterV2.ts
@@ -1,16 +1,18 @@
-import { App, DropdownComponent, Modal, SuggestModal, TextComponent, ToggleComponent } from "obsidian";
-import { VerseSuggesting } from "src/VerseSuggesting";
+import { App, Modal, Setting } from "obsidian";
 import { BibleVersionCollection } from "src/data/BibleVersionCollection";
 import { BibleReferencePluginSettings } from "src/data/constants";
 import { IBibleVersion } from "src/interfaces/IBibleVersion";
+import BibleReferencePlugin from "src/main";
+import { BibleReferenceSettingTab } from "src/ui/BibleReferenceSettingTab";
 
 
 export class VerseModalSuggesterV2 extends Modal {
     settings: BibleReferencePluginSettings
-
-    constructor(app: App, settings: BibleReferencePluginSettings) {
+    plugin: BibleReferencePlugin
+    constructor(app: App, settings: BibleReferencePluginSettings, plugin: BibleReferencePlugin) {
         super(app)
         this.settings = settings
+        this.plugin = plugin
     }
 
     getAllBibleVersionsWithLanguageNameAlphabetically = (): IBibleVersion[] => {
@@ -36,23 +38,30 @@ export class VerseModalSuggesterV2 extends Modal {
     }
 
     onOpen() {
+        this.modalEl.style.width = '40%'
         const { contentEl } = this
+        const settingsInModal = new BibleReferenceSettingTab(this.app, this.plugin)
 
-        const referenceTextBoxDiv = contentEl.createDiv()
-        referenceTextBoxDiv.createEl('div', {text: 'Verse Reference:', cls: 'modal-contents'})
-        new TextComponent (referenceTextBoxDiv)
-            .setPlaceholder('Gen1:1')
+        // Verse Text Box
+        const referenceTextBox = new Setting(contentEl)
+            .setName("Enter Verse Reference:")
+            .addText((text) => text
+                .setPlaceholder('Genesis 1:1')
+                .onChange(async (string) =>{
+                    // Get verses from reference
+                }))
+        
+        // Version Selecter
+        settingsInModal.SetUpVersionSettingsAndVersionOptions(contentEl)
+        
+        // Toggle Version in Reference
+        const versionInReference = new Setting(contentEl)
+            .setName('Include Bible Version in Reference')
+            .setDesc('Include or exclude the Bible translation in the verse citation')
+            .addToggle((toggle) => toggle.setValue(false))
 
-        const translationSelecterDiv = contentEl.createDiv()
-        translationSelecterDiv.createEl('div', {text: 'Select Translation:', cls: 'modal-contents'})
-        new DropdownComponent (translationSelecterDiv)
-            .addOptions(this.formatVersionsIntoObject())
-            .setValue(this.settings.bibleVersion)
-
-        const includeTranslationInReferenceDiv = contentEl.createDiv()
-        includeTranslationInReferenceDiv.createEl('div', {text: 'Include Translation in the Reference:', cls: 'modal-contents'})
-        new ToggleComponent (includeTranslationInReferenceDiv)
-            .setValue(false)
+        // Verse Number Format
+        settingsInModal.SetUpVerseNumberFormatOptions(contentEl)
     }
 
     onClose() {

--- a/src/suggesetor/VersemodalSuggesterV2.ts
+++ b/src/suggesetor/VersemodalSuggesterV2.ts
@@ -38,7 +38,7 @@ export class VerseModalSuggesterV2 extends Modal {
     }
 
     onOpen() {
-        this.modalEl.style.width = '40%'
+        this.modalEl.style.width = 'auto'
         const { contentEl } = this
         contentEl.createEl('h3', {text: 'Insert Verse'})
         const settingsInModal = new BibleReferenceSettingTab(this.app, this.plugin)

--- a/styles.css
+++ b/styles.css
@@ -13,3 +13,8 @@ If your plugin does not need CSS, delete this file.
 .obr-loading-container {
   padding: 1em;
 }
+
+.modal-contents {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}


### PR DESCRIPTION
I had an idea to make a modal with increased functionality. If someone is studying with different versions or wanted to make notes on different versions, they could change it. In addition, with modals, there is future possibility for a variety of commands for different styles of reference. For example, one command might be an inline citation, while another would lead to a embed style citation. 

Here's what the modal I made looks like currently:
![image](https://github.com/tim-hub/obsidian-bible-reference/assets/88126013/08125fac-9bf6-4b4d-83bb-4659d20062cb)

Idea for different reference styles: 
![image](https://github.com/tim-hub/obsidian-bible-reference/assets/88126013/0eb15c9c-4ecf-492b-a4b3-ddbba3a1aeff)

So essentially, you'd be able to use different commands for different reference styles, then you could also easily customize the translation and citation styles in the modal. 

**The modal doesn't work currently.** I am still unfamiliar with how the verse suggesting process works, and it will take a bit for me to figure it out. I will try to learn and implement this properly so people could test it out, but for now, I'm making this draft request to see what people might think about it. 