### PR TITLE
clean up the outgoing links

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -19,8 +19,6 @@ export interface BibleReferencePluginSettings {
   bibleTagging?: boolean
   bookTagging?: boolean
   chapterTagging?: boolean
-  bookBacklinking?: boolean // this is refering to outgoing link
-  chapterBacklinking?: boolean // this is refering to outgoing link
 
   // add this to ui at some point todo
   enableBibleVerseLookupRibbon?: boolean
@@ -35,8 +33,6 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   bibleTagging: false,
   bookTagging: false,
   chapterTagging: false,
-  bookBacklinking: false,
-  chapterBacklinking: false,
   enableBibleVerseLookupRibbon: false,
 }
 

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -207,34 +207,6 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
       )
   }
 
-  setUpBookOutgoingLinking = (containerEl: HTMLElement): void => {
-    new Setting(containerEl)
-      .setName('Add a Book Outgoing Link')
-      .setDesc('Makes an outgoing link for the book, for example [[John]]')
-      .addToggle((toggle) =>
-        toggle
-          .setValue(!!this.plugin.settings?.bookBacklinking)
-          .onChange((value) => {
-            this.plugin.settings.bookBacklinking = value
-            this.plugin.saveData(this.plugin.settings)
-          })
-      )
-  }
-
-  setUpChapterOutgoingLinking = (containerEl: HTMLElement): void => {
-    new Setting(containerEl)
-      .setName('Add a Chapter Outgoing Links')
-      .setDesc('Makes an outgoing link for the chaper, for example [[John1]] ')
-      .addToggle((toggle) =>
-        toggle
-          .setValue(!!this.plugin.settings?.chapterBacklinking)
-          .onChange((value) => {
-            this.plugin.settings.chapterBacklinking = value
-            this.plugin.saveData(this.plugin.settings)
-          })
-      )
-  }
-
   async display(): Promise<void> {
     const {containerEl} = this
     containerEl.empty()
@@ -261,9 +233,6 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
     this.setUpBibleTagging(containerEl)
     this.setUpBookTagging(containerEl)
     this.setUpChapterTagging(containerEl)
-    // todo retire the bottom two settings
-    this.setUpBookOutgoingLinking(containerEl)
-    this.setUpChapterOutgoingLinking(containerEl)
 
     if (flags.isFeatureEnabled('vod')) {
       // todo add vod settings and reflect feature flags

--- a/src/verse/VerseSuggesting.ts
+++ b/src/verse/VerseSuggesting.ts
@@ -38,22 +38,6 @@ export class VerseSuggesting
     this.bibleVersion = settings.bibleVersion
   }
 
-  public get head(): string {
-    let head = super.head
-    // backlinks and tags use the BibleReferenceHeader
-    //  and regex to clean book and chapters that will match
-    //  across multiple different search queires
-    if (this.settings?.bookBacklinking) {
-      head += ` [[${this.verseReference.bookName}]]`
-    }
-    if (this.settings?.chapterBacklinking) {
-      head += ` [[${
-        this.verseReference.bookName + this.verseReference.chapterNumber
-      }]]`
-    }
-    return head
-  }
-
   public get bottom(): string {
     let bottom = super.bottom
     if (


### PR DESCRIPTION
https://github.com/tim-hub/obsidian-bible-reference/discussions/115

![image](https://github.com/tim-hub/obsidian-bible-reference/assets/2884320/13a11a4b-b81c-4e6f-bb7c-6c0648941a7f)

![image](https://github.com/tim-hub/obsidian-bible-reference/assets/2884320/7b0a4f69-f5c7-41ef-a46c-74392ef96061)

I feel like it does not match a clean UI, so just try to remove them here