### PR TITLE
clean up #bible and simplify left over tags

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -16,7 +16,6 @@ export interface BibleReferencePluginSettings {
   verseFormatting?: BibleVerseFormat
   verseNumberFormatting?: BibleVerseNumberFormat
   collapsibleVerses?: boolean
-  bibleTagging?: boolean
   bookTagging?: boolean
   chapterTagging?: boolean
 
@@ -30,7 +29,6 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   verseFormatting: BibleVerseFormat.SingleLine,
   verseNumberFormatting: BibleVerseNumberFormat.Period,
   collapsibleVerses: false,
-  bibleTagging: false,
   bookTagging: false,
   chapterTagging: false,
   enableBibleVerseLookupRibbon: false,

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -165,20 +165,6 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
       )
   }
 
-  setUpBibleTagging = (containerEl: HTMLElement): void => {
-    new Setting(containerEl)
-      .setName('Add a #bible tag')
-      .setDesc('Add a hidden bible tag at bottom, i.e. #bible')
-      .addToggle((toggle) =>
-        toggle
-          .setValue(!!this.plugin.settings?.bibleTagging)
-          .onChange((value) => {
-            this.plugin.settings.bibleTagging = value
-            this.plugin.saveData(this.plugin.settings)
-          })
-      )
-  }
-
   setUpBookTagging = (containerEl: HTMLElement): void => {
     new Setting(containerEl)
       .setName('Add a Book Tag')
@@ -230,7 +216,6 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
         <small>Only if you want to add tags at the bottom of verses</small>
       `
     })
-    this.setUpBibleTagging(containerEl)
     this.setUpBookTagging(containerEl)
     this.setUpChapterTagging(containerEl)
 

--- a/src/verse/VerseSuggesting.ts
+++ b/src/verse/VerseSuggesting.ts
@@ -40,23 +40,16 @@ export class VerseSuggesting
 
   public get bottom(): string {
     let bottom = super.bottom
-    if (
-      this.settings?.bibleTagging ||
-      this.settings?.bookTagging ||
-      this.settings?.chapterTagging
-    ) {
-      bottom += ' %%'
-      bottom += this.settings?.bibleTagging ? ' #bible' : ''
-      bottom += this.settings?.bookTagging
-        ? ` #${this.verseReference.bookName}`
-        : ''
-      bottom += this.settings?.chapterTagging
-        ? ` #${
-            this.verseReference.bookName + this.verseReference.chapterNumber
-          }`
-        : ''
-      bottom += ' %%'
-    }
+    bottom += ' %%'
+    bottom += this.settings?.bookTagging
+      ? ` #${this.verseReference.bookName}`
+      : ''
+    bottom += this.settings?.chapterTagging
+      ? ` #${
+        this.verseReference.bookName + this.verseReference.chapterNumber
+      }`
+      : ''
+    bottom += ' %%'
     return bottom
   }
 


### PR DESCRIPTION
![image](https://github.com/tim-hub/obsidian-bible-reference/assets/2884320/a5a69574-e77b-4d22-9682-17a676d0f802)

I am thinking of removing this setting.

the lower case bible tag  `#bible`