### PR TITLE
ui update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "biblejs-name-converter"]
-	path = biblejs-name-converter
-	url = https://github.com/tim-hub/biblejs-name-converter.git

--- a/src/data/BibleVerseReferenceLinkPosition.ts
+++ b/src/data/BibleVerseReferenceLinkPosition.ts
@@ -2,9 +2,14 @@ export enum BibleVerseReferenceLinkPosition {
   Header = 'Header',
   Bottom = 'Bottom',
   AllAbove = 'Both',
+  None = 'None',
 }
 
 export const BibleVerseReferenceLinkPositionCollection = [
+  {
+    name: BibleVerseReferenceLinkPosition.None,
+    description: 'Hide (Clean and Simple)',
+  },
   {
     name: BibleVerseReferenceLinkPosition.Header,
     description: 'Header (Bible Verse Header)',
@@ -15,6 +20,6 @@ export const BibleVerseReferenceLinkPositionCollection = [
   },
   {
     name: BibleVerseReferenceLinkPosition.AllAbove,
-    description: 'Both (Both of Above)',
+    description: 'Both Header and Bottom',
   },
 ]

--- a/src/data/BibleVersionCollection.ts
+++ b/src/data/BibleVersionCollection.ts
@@ -95,11 +95,11 @@ export const BibleVersionCollection: IBibleVersion[] = [
     language: 'English', code: 'en',
     apiSource: BibleAPISourceCollection.bollsLife,
   },
-   {
+  {
     key: "nasb",
     versionName: "New American Standard Bible (1995)",
     language: "English",
-   code: 'en',
+    code: 'en',
     apiSource: BibleAPISourceCollection.bollsLife
   },
   {
@@ -247,3 +247,13 @@ export const DEFAULT_BIBLE_VERSION = BibleVersionCollection[11]
 export const getBibleVersion = (key: string): IBibleVersion => {
   return BibleVersionCollection.find(bibleVersion => bibleVersion.key === key) ?? DEFAULT_BIBLE_VERSION
 }
+
+export const allBibleVersionsWithLanguageNameAlphabetically: IBibleVersion[] = BibleVersionCollection.sort((a, b) => {
+  // sort by language and versionName alphabetically
+  const languageCompare = a.language.localeCompare(b.language)
+  if (languageCompare === 0) {
+    return a.versionName.localeCompare(b.versionName)
+  } else {
+    return languageCompare
+  }
+})

--- a/src/data/BibleVersionCollection.ts
+++ b/src/data/BibleVersionCollection.ts
@@ -242,3 +242,8 @@ export const BibleVersionCollection: IBibleVersion[] = [
 ]
 
 export const DEFAULT_BIBLE_VERSION = BibleVersionCollection[11]
+
+
+export const getBibleVersion = (key: string): IBibleVersion => {
+  return BibleVersionCollection.find(bibleVersion => bibleVersion.key === key) ?? DEFAULT_BIBLE_VERSION
+}

--- a/src/data/abbreviations.ts
+++ b/src/data/abbreviations.ts
@@ -1,6 +1,7 @@
 /**
  * better https://www.logos.com/bible-book-abbreviations
  * https://github.com/TehShrike/books-of-the-bible/blob/master/index.json
+ * This is not used so far, todo consider delete this or use this
  */
 export const books = [
   {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -22,6 +22,8 @@ export interface BibleReferencePluginSettings {
   // add this to ui at some point todo
   enableBibleVerseLookupRibbon?: boolean
   optOutToEvents?: boolean
+
+  advancedSettings?: boolean;
 }
 
 export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -10,6 +10,12 @@ export const APP_NAMING = {
   defaultStatus: '',
 }
 
+export enum OutgoingLinkPositionEnum {
+  Header = BibleVerseReferenceLinkPosition.Header,
+  Bottom = BibleVerseReferenceLinkPosition.Bottom,
+  None = BibleVerseReferenceLinkPosition.None,
+}
+
 export interface BibleReferencePluginSettings {
   bibleVersion: string
   referenceLinkPosition?: BibleVerseReferenceLinkPosition
@@ -18,6 +24,8 @@ export interface BibleReferencePluginSettings {
   collapsibleVerses?: boolean
   bookTagging?: boolean
   chapterTagging?: boolean
+  bookBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
+  chapterBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
 
   // add this to ui at some point todo
   enableBibleVerseLookupRibbon?: boolean
@@ -36,6 +44,8 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   chapterTagging: false,
   enableBibleVerseLookupRibbon: false,
   optOutToEvents: false,
+  bookBacklinking: OutgoingLinkPositionEnum.None,
+  chapterBacklinking: OutgoingLinkPositionEnum.None,
 }
 
 export const API_WAITING_LABEL = 'Loading...'

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,16 +188,18 @@ export default class BibleReferencePlugin extends Plugin {
   private initStatusBarInidactor(): void {
     // This adds a status bar item to the bottom of the app. Does not work on mobile apps.
     this.removeStatusBarIndicator();
+    const bibleVersion = getBibleVersion(this.settings.bibleVersion)
     this.statusBarIndicator = this.addStatusBarItem()
     // todo add an icon
     this.statusBarIndicator.createEl('span', {
       text: `${bibleVersion.versionName}(${bibleVersion.language})`,
       cls: 'bible-version-indicator'
     });
-    const versionChangeEventRef = pluginEvent.on('bible-reference:settings:version', () => {
+    // create event listener for the update
+    pluginEvent.on('bible-reference:settings:version', () => {
       this.updateStatusBarIndicator()
     })
-    this.registerEvent(versionChangeEventRef)
+    // this.registerEvent(versionChangeEventRef) // somehow this is not necessary
   }
 
 
@@ -210,7 +212,9 @@ export default class BibleReferencePlugin extends Plugin {
 
   private updateStatusBarIndicator(): void {
     const bibleVersion = getBibleVersion(this.settings.bibleVersion)
-    // @ts-ignore
-    this.statusBarIndicator?.getElementsByClassName('bible-version-indicator')[0].innerText = `${bibleVersion.versionName}(${bibleVersion.language})`
+    if (this.statusBarIndicator && 'getElementsByClassName' in this.statusBarIndicator) {
+      const el = this.statusBarIndicator.getElementsByClassName('bible-version-indicator')[0]
+      el.innerHTML = `${bibleVersion.versionName}(${bibleVersion.language})`
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ import { splitBibleReference } from './utils/splitBibleReference'
 import { VerseOfDaySuggesting } from './verse/VerseOfDaySuggesting'
 import { FlagService } from './provider/FeatureFlag'
 import { EventStats } from './provider/EventStats'
+import { getBibleVersion } from './data/BibleVersionCollection';
+import { pluginEvent } from './obsidian/PluginEvent';
 
 export default class BibleReferencePlugin extends Plugin {
   settings: BibleReferencePluginSettings
@@ -25,9 +27,10 @@ export default class BibleReferencePlugin extends Plugin {
     timestamp: number
   }
   private ribbonButton?: HTMLElement
+  private statusBarIndicator?: HTMLElement
 
   async onload() {
-    console.log('loading plugin -', APP_NAMING.appName)
+    console.debug('loading plugin -', APP_NAMING.appName)
 
     await this.loadSettings()
     this.addSettingTab(new BibleReferenceSettingTab(this.app, this))
@@ -55,11 +58,16 @@ export default class BibleReferencePlugin extends Plugin {
         this.addVerseOfDayNoticeCommand()
       }
     }
+
+    this.initStatusBarInidactor()
     EventStats.logRecord(this.settings.optOutToEvents)
   }
 
   onunload() {
-    console.log('unloading plugin', APP_NAMING.appName)
+    console.debug('unloading plugin', APP_NAMING.appName)
+    this.removeRibbonButton()
+    this.removeStatusBarIndicator()
+    pluginEvent.offAll(); // so that we don't have to worry about off ref in multiple places
   }
 
   async loadSettings() {
@@ -72,8 +80,8 @@ export default class BibleReferencePlugin extends Plugin {
   }
 
   private async getAndCachedVerseOfDay(): Promise<VerseOfDaySuggesting> {
-    const { ttl, timestamp, verseOfDaySuggesting } =
-      this?.cachedVerseOfDaySuggesting || {}
+    const {ttl, timestamp, verseOfDaySuggesting} =
+    this?.cachedVerseOfDaySuggesting || {}
     if (!verseOfDaySuggesting || timestamp + ttl > Date.now()) {
       const vodResp = await getVod()
       const reference = splitBibleReference(vodResp.verse.details.reference)
@@ -99,7 +107,7 @@ export default class BibleReferencePlugin extends Plugin {
       callback: () => {
         EventStats.logUIOpen(
           'lookupModalOpen',
-          { key: `command-lookup`, value: 1 },
+          {key: `command-lookup`, value: 1},
           this.settings.optOutToEvents
         )
         this.verseLookUpModal.open()
@@ -116,7 +124,7 @@ export default class BibleReferencePlugin extends Plugin {
         const verse = await this.getAndCachedVerseOfDay()
         EventStats.logUIOpen(
           'vodEditorOpen',
-          { key: `command-vod`, value: 1 },
+          {key: `command-vod`, value: 1},
           this.settings.optOutToEvents
         )
         new Notice(
@@ -137,7 +145,7 @@ export default class BibleReferencePlugin extends Plugin {
         const vodSuggesting = await this.getAndCachedVerseOfDay()
         EventStats.logUIOpen(
           'vodEditorOpen',
-          { key: `command-vod-insert`, value: 1 },
+          {key: `command-vod-insert`, value: 1},
           this.settings.optOutToEvents
         )
         editor.replaceSelection(vodSuggesting.allFormattedContent)
@@ -154,7 +162,7 @@ export default class BibleReferencePlugin extends Plugin {
       (_evt) => {
         EventStats.logUIOpen(
           'lookupModalOpen',
-          { key: `ribbon-click`, value: 1 },
+          {key: `ribbon-click`, value: 1},
           this.settings.optOutToEvents
         )
         this.verseLookUpModal.open()
@@ -166,10 +174,43 @@ export default class BibleReferencePlugin extends Plugin {
     if (this.ribbonButton) {
       EventStats.logUIOpen(
         'lookupModalOpen',
-        { key: `ribbon-remove`, value: 1 },
+        {key: `ribbon-remove`, value: 1},
         this.settings.optOutToEvents
       )
       this.ribbonButton.parentNode?.removeChild(this.ribbonButton)
     }
+  }
+
+  /**
+   * To indicate user the Bible version selected
+   * @private
+   */
+  private initStatusBarInidactor(): void {
+    // This adds a status bar item to the bottom of the app. Does not work on mobile apps.
+    this.removeStatusBarIndicator();
+    this.statusBarIndicator = this.addStatusBarItem()
+    // todo add an icon
+    this.statusBarIndicator.createEl('span', {
+      text: `${bibleVersion.versionName}(${bibleVersion.language})`,
+      cls: 'bible-version-indicator'
+    });
+    const versionChangeEventRef = pluginEvent.on('bible-reference:settings:version', () => {
+      this.updateStatusBarIndicator()
+    })
+    this.registerEvent(versionChangeEventRef)
+  }
+
+
+  private removeStatusBarIndicator(): void {
+    if (this.statusBarIndicator) {
+      this.statusBarIndicator.parentNode?.removeChild(this.statusBarIndicator)
+    }
+  }
+
+
+  private updateStatusBarIndicator(): void {
+    const bibleVersion = getBibleVersion(this.settings.bibleVersion)
+    // @ts-ignore
+    this.statusBarIndicator?.getElementsByClassName('bible-version-indicator')[0].innerText = `${bibleVersion.versionName}(${bibleVersion.language})`
   }
 }

--- a/src/obsidian/PluginEvent.ts
+++ b/src/obsidian/PluginEvent.ts
@@ -1,0 +1,33 @@
+import { Events, EventRef } from 'obsidian';
+
+// ref this article https://shbgm.ca/blog/obsidian/plugin-development/custom-events
+export class PluginEvent extends Events {
+  private static instance: PluginEvent;
+  protected refs: EventRef[] = [];
+
+  constructor() {
+    super();
+  }
+
+  public static getInstance(): PluginEvent {
+    if (!PluginEvent.instance) {
+      PluginEvent.instance = new PluginEvent();
+    }
+    return PluginEvent.instance;
+  }
+
+  on(name: string, callback: (...data: any) => any, ctx?: any): EventRef {
+    const ref = super.on(name, callback, ctx);
+    this.refs.push(ref);
+    return ref;
+  }
+
+  public offAll() {
+    this.refs.forEach((ref) => {
+      this.offref(ref)
+    });
+  }
+}
+
+
+export const pluginEvent = PluginEvent.getInstance();

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -100,7 +100,7 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
   setUpReferenceLinkPositionOptions = (containerEl: HTMLElement): void => {
     new Setting(containerEl)
       .setName('Verse Reference Link Position')
-      .setDesc('Where to put the bible verse reference link of the bible')
+      .setDesc('Where to put the reference link of the Bible')
       .addDropdown((dropdown: DropdownComponent) => {
         BibleVerseReferenceLinkPositionCollection.forEach(
           ({ name, description }) => {
@@ -110,7 +110,7 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
         dropdown
           .setValue(
             this.plugin.settings.referenceLinkPosition ??
-              BibleVerseReferenceLinkPosition.Bottom
+              BibleVerseReferenceLinkPosition.None
           )
           .onChange(async (value) => {
             this.plugin.settings.referenceLinkPosition =

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -27,6 +27,7 @@ import { FlagService } from '../provider/FeatureFlag'
 import { BibleAPISourceCollection } from '../data/BibleApiSourceCollection'
 import { EventStats } from '../provider/EventStats'
 import { APP_NAMING } from '../data/constants'
+import { pluginEvent } from '../obsidian/PluginEvent';
 
 export class BibleReferenceSettingTab extends PluginSettingTab {
   plugin: BibleReferencePlugin
@@ -87,6 +88,7 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
             this.plugin.settings.bibleVersion = value
             console.debug('Default Bible Version: ' + value)
             await this.plugin.saveSettings()
+            pluginEvent.trigger('bible-reference:settings:version', [value])
             new Notice(`Bible Reference - use Version ${value.toUpperCase()}`)
             EventStats.logSettingChange(
               'changeVersion',

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -84,22 +84,22 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
       if (this.plugin.settings.advancedSettings) {
         this.displayExpertSettings();
       } else {
-        this.expertSettingContainer.empty();
+        this.expertSettingContainer && this.expertSettingContainer.empty();
       }
     })
   }
 
   private displayExpertSettings(): void {
-    this.expertSettingContainer.createEl('hr')
-    this.expertSettingContainer.createEl('h2', {text: 'Expert Settings'})
-    this.expertSettingContainer.createEl('h5', {text: 'Tagging and Linking Settings'})
-    this.expertSettingContainer.createSpan({}, (span) => {
-      span.innerHTML = `
+    if (this.expertSettingContainer) {
+      this.expertSettingContainer.createEl('hr')
+      this.expertSettingContainer.createEl('h2', {text: 'Expert Settings'})
+      this.expertSettingContainer.createEl('h5', {text: 'Tagging and Linking Settings'})
+      this.expertSettingContainer.createSpan({}, (span) => {
+        span.innerHTML = `
         <small>Only if you want to add tags at the bottom of verses</small>
       `
-    })
+      })
 
-    if (this.expertSettingContainer) {
       new Setting(this.expertSettingContainer)
         .setName('Add a Book Tag')
         .setDesc('Add a hidden book tag at bottom, for example #John')
@@ -144,8 +144,8 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
               dropdown.addOption(name, name)
             }
           )
-          const defaultPosition = this.plugin.settings?.bookBacklinking === true ? OutgoingLinkPositionEnum.Header : OutgoingLinkPositionEnum.None
-          const value: string = (this.plugin.settings?.bookBacklinking && this.plugin.settings?.bookBacklinking !== true ? this.plugin.settings.bookBacklinking : defaultPosition) as string
+          const defaultPosition = this.plugin.settings?.bookBacklinking as any === true ? OutgoingLinkPositionEnum.Header : OutgoingLinkPositionEnum.None
+          const value: string = (this.plugin.settings?.bookBacklinking && this.plugin.settings?.bookBacklinking as any !== true ? this.plugin.settings.bookBacklinking : defaultPosition) as string
           dropdown.setValue(value)
           dropdown.onChange(async (value) => {
             this.plugin.settings.bookBacklinking = value as OutgoingLinkPositionEnum
@@ -162,8 +162,8 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
               dropdown.addOption(name, name)
             }
           )
-          const defaultPosition = this.plugin.settings?.chapterBacklinking === true ? OutgoingLinkPositionEnum.Header : OutgoingLinkPositionEnum.None
-          const value: string = (this.plugin.settings?.chapterBacklinking && this.plugin.settings?.chapterBacklinking !== true ? this.plugin.settings.chapterBacklinking : defaultPosition) as string
+          const defaultPosition = this.plugin.settings?.chapterBacklinking as any === true ? OutgoingLinkPositionEnum.Header : OutgoingLinkPositionEnum.None
+          const value: string = (this.plugin.settings?.chapterBacklinking && this.plugin.settings?.chapterBacklinking as any !== true ? this.plugin.settings.chapterBacklinking : defaultPosition) as string
           dropdown.setValue(value)
           dropdown.onChange(async (value) => {
             this.plugin.settings.chapterBacklinking = value as OutgoingLinkPositionEnum

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -26,7 +26,7 @@ import {
 import { FlagService } from '../provider/FeatureFlag'
 import { BibleAPISourceCollection } from '../data/BibleApiSourceCollection'
 import { EventStats } from '../provider/EventStats'
-import { APP_NAMING } from '../data/constants'
+import { APP_NAMING, OutgoingLinkPositionEnum } from '../data/constants'
 import { pluginEvent } from '../obsidian/PluginEvent';
 
 export class BibleReferenceSettingTab extends PluginSettingTab {
@@ -67,15 +67,15 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
     `
     })
 
+    this.expertSettingContainer = this.containerEl.createDiv()
+    if (this.plugin.settings.advancedSettings) {
+      this.displayExpertSettings();
+    }
     EventStats.logUIOpen(
       'settingsOpen',
       {key: 'open', value: 1},
       this.plugin.settings.optOutToEvents
     )
-    this.expertSettingContainer = this.containerEl.createDiv()
-    if (this.plugin.settings.advancedSettings) {
-      this.displayExpertSettings();
-    }
   }
 
   private startListeningToEvents(): void {
@@ -134,6 +134,42 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
               }
             )
         )
+
+      new Setting(this.expertSettingContainer)
+        .setName('Add a Book Outgoing Link')
+        .setDesc('Makes an outgoing link for the book, for example [[John]]')
+        .addDropdown((dropdown) => {
+          Object.keys(OutgoingLinkPositionEnum).forEach(
+            (name) => {
+              dropdown.addOption(name, name)
+            }
+          )
+          const defaultPosition = this.plugin.settings?.bookBacklinking === true ? OutgoingLinkPositionEnum.Header : OutgoingLinkPositionEnum.None
+          const value: string = (this.plugin.settings?.bookBacklinking && this.plugin.settings?.bookBacklinking !== true ? this.plugin.settings.bookBacklinking : defaultPosition) as string
+          dropdown.setValue(value)
+          dropdown.onChange(async (value) => {
+            this.plugin.settings.bookBacklinking = value as OutgoingLinkPositionEnum
+            await this.plugin.saveSettings()
+          })
+        })
+
+      new Setting(this.expertSettingContainer)
+        .setName('Add a Chapter Outgoing Links')
+        .setDesc('Makes an outgoing link for the chapter, for example [[John1]] ')
+        .addDropdown((dropdown) => {
+          Object.keys(OutgoingLinkPositionEnum).forEach(
+            (name) => {
+              dropdown.addOption(name, name)
+            }
+          )
+          const defaultPosition = this.plugin.settings?.chapterBacklinking === true ? OutgoingLinkPositionEnum.Header : OutgoingLinkPositionEnum.None
+          const value: string = (this.plugin.settings?.chapterBacklinking && this.plugin.settings?.chapterBacklinking !== true ? this.plugin.settings.chapterBacklinking : defaultPosition) as string
+          dropdown.setValue(value)
+          dropdown.onChange(async (value) => {
+            this.plugin.settings.chapterBacklinking = value as OutgoingLinkPositionEnum
+            await this.plugin.saveSettings()
+          })
+        })
     }
   }
 
@@ -290,7 +326,7 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
   private setUpExpertSettings(): void {
     new Setting(this.containerEl)
       .setName('Expert Settings')
-      .setDesc('Display or Hide Expert Settings')
+      .setDesc('Display or Hide Expert Settings, such as Tagging and Linking settings')
       .addToggle((toggle) =>
         toggle
           .setValue(!!this.plugin.settings?.advancedSettings)

--- a/src/utils/getSuggestionsFromQuery.ts
+++ b/src/utils/getSuggestionsFromQuery.ts
@@ -2,8 +2,7 @@ import { BibleReferencePluginSettings } from '../data/constants'
 import { VerseSuggesting } from '../verse/VerseSuggesting'
 import { BOOK_REG } from './regs'
 import { getFullBookName } from './bookNameReference';
-import { BibleVersionCollection } from '../data/BibleVersionCollection';
-import { IBibleVersion } from '../interfaces/IBibleVersion';
+import { getBibleVersion } from '../data/BibleVersionCollection';
 
 /**
  * Get suggestions from string query
@@ -29,7 +28,7 @@ export const getSuggestionsFromQuery = async (
   const verseNumber = parseInt(numbers[1])
   const verseEndNumber = numbers.length === 3 ? parseInt(numbers[2]) : undefined
 
-  const selectedBibleVersion = BibleVersionCollection.find((bible: IBibleVersion) => bible.key === settings.bibleVersion)
+  const selectedBibleVersion = getBibleVersion(settings.bibleVersion)
   const bookName = getFullBookName(rawBookName, selectedBibleVersion?.code)
   console.debug('bookName', bookName)
 

--- a/src/verse/VerseSuggesting.ts
+++ b/src/verse/VerseSuggesting.ts
@@ -1,4 +1,4 @@
-import { BibleReferencePluginSettings, DEFAULT_SETTINGS, } from '../data/constants'
+import { BibleReferencePluginSettings, DEFAULT_SETTINGS, OutgoingLinkPositionEnum, } from '../data/constants'
 import { getBibleVersion } from '../data/BibleVersionCollection'
 import { IVerse } from '../interfaces/IVerse'
 import { ProviderFactory } from '../provider/ProviderFactory'
@@ -33,6 +33,13 @@ export class VerseSuggesting
     this.bibleVersion = settings.bibleVersion
   }
 
+  public get head(): string {
+    let content = super.head;
+    content += this.settings?.bookBacklinking === OutgoingLinkPositionEnum.Header ? ` [[${this.verseReference.bookName}]]` : ''
+    content += this.settings?.chapterBacklinking === OutgoingLinkPositionEnum.Header ? ` [[${this.verseReference.bookName} ${this.verseReference.chapterNumber}]]` : ''
+    return content;
+  }
+
   public get bottom(): string {
     let bottom = super.bottom
     if (this.settings?.bookTagging || this.settings?.chapterTagging) {
@@ -44,6 +51,11 @@ export class VerseSuggesting
         ? ` #${this.verseReference.bookName + this.verseReference.chapterNumber}`
         : ''
       bottom += ' %%'
+    }
+    if (this.settings?.bookBacklinking === OutgoingLinkPositionEnum.Bottom || this.settings?.chapterBacklinking === OutgoingLinkPositionEnum.Bottom) {
+      bottom += '>\n '
+      bottom += this.settings?.bookBacklinking === OutgoingLinkPositionEnum.Bottom ? ` [[${this.verseReference.bookName}]]` : ''
+      bottom += this.settings?.chapterBacklinking === OutgoingLinkPositionEnum.Bottom ? ` [[${this.verseReference.bookName} ${this.verseReference.chapterNumber}]]` : ''
     }
     return bottom
   }

--- a/src/verse/VerseSuggesting.ts
+++ b/src/verse/VerseSuggesting.ts
@@ -1,9 +1,5 @@
-import {
-  BibleReferencePluginSettings,
-  DEFAULT_SETTINGS,
-} from '../data/constants'
-import { BibleVersionCollection } from '../data/BibleVersionCollection'
-import { IBibleVersion } from '../interfaces/IBibleVersion'
+import { BibleReferencePluginSettings, DEFAULT_SETTINGS, } from '../data/constants'
+import { getBibleVersion } from '../data/BibleVersionCollection'
 import { IVerse } from '../interfaces/IVerse'
 import { ProviderFactory } from '../provider/ProviderFactory'
 import { BaseBibleAPIProvider } from '../provider/BaseBibleAPIProvider'
@@ -16,8 +12,7 @@ import { IVerseSuggesting } from './IVerseSuggesting'
  */
 export class VerseSuggesting
   extends BaseVerseFormatter
-  implements IVerseSuggesting
-{
+  implements IVerseSuggesting {
   public bibleVersion: string
   private bibleProvider: BaseBibleAPIProvider
 
@@ -57,20 +52,14 @@ export class VerseSuggesting
    * Render for use in editor/modal suggest
    */
   public renderSuggestion(el: HTMLElement) {
-    const outer = el.createDiv({ cls: 'obr-suggester-container' })
+    const outer = el.createDiv({cls: 'obr-suggester-container'})
     // @ts-ignore
-    outer.createDiv({ cls: 'obr-shortcode' }).setText(this.bodyContent)
+    outer.createDiv({cls: 'obr-shortcode'}).setText(this.bodyContent)
   }
 
   public async fetchAndSetVersesText(): Promise<void> {
     // todo add a caching here, this might not be possible with Obsidian limit
     this.verses = await this.getVerses()
-  }
-
-  protected getVerseReferenceLink(): string {
-    return ` [${
-      this.bibleProvider.BibleReferenceHead
-    } - ${this.bibleVersion.toUpperCase()}](${this.bibleProvider.VerseLinkURL})`
   }
 
   public async getVerses(): Promise<IVerse[]> {
@@ -79,9 +68,7 @@ export class VerseSuggesting
       console.debug('match to default language plus version')
     }
     const bibleVersion =
-      BibleVersionCollection.find(
-        (bv: IBibleVersion) => bv.key === this.bibleVersion
-      ) ?? BibleVersionCollection[0]
+      getBibleVersion(this.bibleVersion)
     if (
       !this.bibleProvider ||
       this.bibleProvider.BibleVersionKey !== bibleVersion?.key
@@ -99,5 +86,11 @@ export class VerseSuggesting
         ? [this.verseReference.verseNumber, this.verseReference.verseNumberEnd]
         : [this.verseReference.verseNumber]
     )
+  }
+
+  protected getVerseReferenceLink(): string {
+    return ` [${
+      this.bibleProvider.BibleReferenceHead
+    } - ${this.bibleVersion.toUpperCase()}](${this.bibleProvider.VerseLinkURL})`
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,9 @@
-/* <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --> */
 .callout[data-callout="bible"] {
   /*--callout-color: 0, 0, 0;*/
+  /*fa-book-bible"*/
+  /* <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --> */
   --callout-icon: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'><path d='M448 336v-288C448 21.49 426.5 0 400 0H96C42.98 0 0 42.98 0 96v320c0 53.02 42.98 96 96 96h320c17.67 0 32-14.33 32-31.1c0-11.72-6.607-21.52-16-27.1v-81.36C441.8 362.8 448 350.2 448 336zM144 144c0-8.875 7.125-15.1 16-15.1L208 128V80c0-8.875 7.125-15.1 16-15.1l32 .0009c8.875 0 16 7.12 16 15.1V128L320 128c8.875 0 16 7.121 16 15.1v32c0 8.875-7.125 16-16 16L272 192v112c0 8.875-7.125 16-16 16l-32-.0002c-8.875 0-16-7.127-16-16V192L160 192c-8.875 0-16-7.127-16-16V144zM384 448H96c-17.67 0-32-14.33-32-32c0-17.67 14.33-32 32-32h288V448z'/></svg>";
- }
+}
 
 .obr-loading-container {
   padding: 1em;


### PR DESCRIPTION
This is a PR to add Bible version status text at status bar
And to bring the linking back, which is sort of revert this PR https://github.com/tim-hub/obsidian-bible-reference/pull/119 and to resolve this issue https://github.com/tim-hub/obsidian-bible-reference/issues/128 and partially resolve this discussion https://github.com/tim-hub/obsidian-bible-reference/discussions/127%5D



- update UI for reference link position
- merge upstream
  -  Adapt to plugin guidelines 
- fact get bible version
- fact, put license in right place in css and add a comment in abbreviations.ts
- use event to sync status text of version
- add expert settings section
- add the linking back
- fix type error
