### PR TITLE
Fixed display of book names with spaces

### DIFF
--- a/src/provider/BibleAPIDotComProvider.ts
+++ b/src/provider/BibleAPIDotComProvider.ts
@@ -20,7 +20,7 @@ export class BibleAPIDotComProvider extends BaseBibleAPIProvider {
     verses: number[],
     versionName?: string
   ): string {
-    let queryString = `${bookName}+${chapter}:`
+    let queryString = encodeURIComponent(`${bookName}+${chapter}:`)
     if (verses?.length >= 3) {
       queryString += verses.join('&')
     } else if (verses?.length === 2 && !!verses[1]) {

--- a/src/provider/BibleAPIDotComProvider.ts
+++ b/src/provider/BibleAPIDotComProvider.ts
@@ -20,7 +20,7 @@ export class BibleAPIDotComProvider extends BaseBibleAPIProvider {
     verses: number[],
     versionName?: string
   ): string {
-    let queryString = encodeURIComponent(`${bookName}+${chapter}:`)
+    let queryString = `${bookName}+${chapter}:`.replace(/ /g, '+')
     if (verses?.length >= 3) {
       queryString += verses.join('&')
     } else if (verses?.length === 2 && !!verses[1]) {


### PR DESCRIPTION
Currently, the query `--2 Samuel 7:16` creates the following output:

```
> [!bible]+ [2 Samuel 7:16 - KJV](https://bible-api.com/2 Samuel+7:16?translation=kjv)
>  16. And thine house and thy kingdom shall be established for ever before thee: thy throne shall be established for ever.
```

<img width="531" alt="Screenshot 2023-11-10 at 11 21 30 AM" src="https://github.com/tim-hub/obsidian-bible-reference/assets/5573638/9307e55c-0541-46ac-a94f-f266acd90038">

This has a space in the query path, which prevents the link label from being displayed correctly.

This PR replaces spaces with `+`, which gives the following output:

```
> [!bible]+ [2 Samuel 7:16 - KJV](https://bible-api.com/2+Samuel+7:16?translation=kjv)
>  16. And thine house and thy kingdom shall be established for ever before thee: thy throne shall be established for ever.
```

<img width="522" alt="Screenshot 2023-11-10 at 11 21 41 AM" src="https://github.com/tim-hub/obsidian-bible-reference/assets/5573638/42806f1d-23eb-47cd-a87d-2998fb34dcce">

