### PR TITLE
Added ability to specify alternate version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vscode
 # npm
 node_modules
+package-lock.json
 
 # build
 main.js

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -24,6 +24,7 @@ export enum BibleVersionNameLengthEnum {
 
 export interface BibleReferencePluginSettings {
   bibleVersion: string
+  defaultBibleVersion: string
   referenceLinkPosition?: BibleVerseReferenceLinkPosition
   verseFormatting?: BibleVerseFormat
   verseNumberFormatting?: BibleVerseNumberFormat
@@ -46,6 +47,7 @@ export interface BibleReferencePluginSettings {
 
 export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   bibleVersion: DEFAULT_BIBLE_VERSION.key,
+  defaultBibleVersion: DEFAULT_BIBLE_VERSION.key,
   referenceLinkPosition: BibleVerseReferenceLinkPosition.Header,
   verseFormatting: BibleVerseFormat.SingleLine,
   verseNumberFormatting: BibleVerseNumberFormat.Period,

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -239,6 +239,7 @@ Obsidian Bible Reference  is proudly powered by
           .setValue(this.plugin.settings.bibleVersion)
           .onChange(async (value) => {
             this.plugin.settings.bibleVersion = value
+            this.plugin.settings.defaultBibleVersion = value
             console.debug('Default Bible Version: ' + value)
             await this.plugin.saveSettings()
             pluginEvent.trigger('bible-reference:settings:version', [value])

--- a/src/utils/reg.test.ts
+++ b/src/utils/reg.test.ts
@@ -1,4 +1,4 @@
-import { BOOK_REG, MODAL_REG } from './regs'
+import { BOOK_REG, MODAL_REG, VERSION_REG } from './regs'
 
 describe('test book name reg matching in different languages', () => {
   test('should match book name in English', () => {
@@ -74,4 +74,23 @@ describe('test modal reg matching in different languages', () => {
     const reg = new RegExp(MODAL_REG)
     expect(reg.test(modal)).toBe(false)
   })
+
+  test('should match version with only alphabets', () => {
+    const modal = '-niv2011'
+    const reg = new RegExp(VERSION_REG)
+    expect(reg.test(modal)).toBe(true)
+  })
+  
+  test('should match version with numbers', () => {
+    const modal = '-niv2011'
+    const reg = new RegExp(VERSION_REG)
+    expect(reg.test(modal)).toBe(true)
+  })
+
+  test('should not match when there is hyphen', () => {
+    const modal = '-should-fail'
+    const reg = new RegExp(MODAL_REG)
+    expect(reg.test(modal)).toBe(false)
+  })
+
 })

--- a/src/utils/regs.ts
+++ b/src/utils/regs.ts
@@ -11,7 +11,7 @@ export const MODAL_REG = /([123])*\s*([\p{L}[\\\]^_`a-zA-Z]{2,100}|\p{Script=Han
 
 export const BOOK_REG = /([123])*\s*([\p{L}[\\\]^_`a-zA-Z]{2,100}|\p{Script=Han}{1,})/isu
 
-export const VERSION_REG = /(-[a-zA-Z0-9-]+)$/isu
+export const VERSION_REG = /(-[a-zA-Z0-9]+)$/isu
 
 // export const BOOK_REG = /[123]*\s*[A-Z\[\\\]^_`a-z]{2,}/
 

--- a/src/utils/regs.ts
+++ b/src/utils/regs.ts
@@ -11,6 +11,8 @@ export const MODAL_REG = /([123])*\s*([\p{L}[\\\]^_`a-zA-Z]{2,100}|\p{Script=Han
 
 export const BOOK_REG = /([123])*\s*([\p{L}[\\\]^_`a-zA-Z]{2,100}|\p{Script=Han}{1,})/isu
 
+export const VERSION_REG = /(-[a-zA-Z0-9-]+)$/isu
+
 // export const BOOK_REG = /[123]*\s*[A-Z\[\\\]^_`a-z]{2,}/
 
 /**

--- a/src/utils/versionMatch.ts
+++ b/src/utils/versionMatch.ts
@@ -1,0 +1,16 @@
+import { VERSION_REG } from './regs'
+
+/**
+ * check if the given string contains a verseNumber, and return the verseNumber if it does
+ * @param verseTrigger without the prefix trigger --
+ * @returns string the same string if it match
+ */
+export const versionMatch = (verseTrigger: string): string => {
+  const matchResults = verseTrigger.match(VERSION_REG)
+  console.log(`version reg match result : ${matchResults}`)
+  if (!matchResults) {
+    return ''
+  } else {
+    return matchResults[0].substring(1)
+  }
+}


### PR DESCRIPTION
### Usage
`--matt1:1-esv`
`--matt1:1-niv2011`


Added regex to match the versions.
Created a constant `defaultBibleVersion` to fall back on if the specified version is not in `BibleVersionCollection`.