### PR TITLE
fix querying multiple verse

### DIFF
--- a/src/suggesetor/VerseEditorSuggester.ts
+++ b/src/suggesetor/VerseEditorSuggester.ts
@@ -55,13 +55,11 @@ export class VerseEditorSuggester extends EditorSuggest<VerseSuggesting> {
     const queryContent = currentContent.substring(2)
 
     const match = verseMatch(queryContent)
-    
     if (match) {
-
       const vMatch = versionMatch(queryContent)
       if (vMatch) {
-        this.plugin.settings.bibleVersion = vMatch
         if (getBibleVersion(vMatch).key == vMatch) {
+          this.plugin.settings.bibleVersion = vMatch
           this.plugin.saveSettings()
         }
       } else {

--- a/src/utils/reg.test.ts
+++ b/src/utils/reg.test.ts
@@ -76,7 +76,7 @@ describe('test modal reg matching in different languages', () => {
   })
 
   test('should match version with only alphabets', () => {
-    const modal = '-niv2011'
+    const modal = '-esv'
     const reg = new RegExp(VERSION_REG)
     expect(reg.test(modal)).toBe(true)
   })
@@ -87,10 +87,10 @@ describe('test modal reg matching in different languages', () => {
     expect(reg.test(modal)).toBe(true)
   })
 
-  test('should not match when there is hyphen', () => {
-    const modal = '-should-fail'
-    const reg = new RegExp(MODAL_REG)
-    expect(reg.test(modal)).toBe(false)
+  test('should match even when there is hyphen', () => {
+    const modal = '-oeb-cw'
+    const reg = new RegExp(VERSION_REG)
+    expect(reg.test(modal)).toBe(true)
   })
 
 })

--- a/src/utils/regs.ts
+++ b/src/utils/regs.ts
@@ -11,7 +11,7 @@ export const MODAL_REG = /([123])*\s*([\p{L}[\\\]^_`a-zA-Z]{2,100}|\p{Script=Han
 
 export const BOOK_REG = /([123])*\s*([\p{L}[\\\]^_`a-zA-Z]{2,100}|\p{Script=Han}{1,})/isu
 
-export const VERSION_REG = /(-[a-zA-Z0-9]+)$/isu
+export const VERSION_REG = /-[a-zA-Z][a-zA-Z0-9-]*$/isu 
 
 // export const BOOK_REG = /[123]*\s*[A-Z\[\\\]^_`a-z]{2,}/
 


### PR DESCRIPTION
- fixed error querying multiple verses (made changes to regex)
- allow for versions with hyphen (e.g. `oeb-cw` and `oeb-us`)
