### PR TITLE
Add toggle command for Bible Icon Prefix setting, and add collapsible option for callout options

### DIFF
--- a/src/data/CollapsibleVerses.ts
+++ b/src/data/CollapsibleVerses.ts
@@ -1,0 +1,20 @@
+export enum CollapsibleVerses {
+    Plus = '+',
+    Minus = '-',
+    None = 'None'
+}
+
+export const CollapsibleVersesCollection = [
+    {
+        name: CollapsibleVerses.Plus,
+        description: 'Plus',
+    },
+    {
+        name: CollapsibleVerses.Minus,
+        description: 'Minus',
+    },
+    {
+        name: CollapsibleVerses.None,
+        description: 'None',
+    },
+]

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -2,6 +2,7 @@ import { DEFAULT_BIBLE_VERSION } from './BibleVersionCollection'
 import { BibleVerseReferenceLinkPosition } from './BibleVerseReferenceLinkPosition'
 import { BibleVerseFormat } from './BibleVerseFormat'
 import { BibleVerseNumberFormat } from './BibleVerseNumberFormat'
+import { CollapsibleVerses } from './CollapsibleVerses'
 
 export const APP_NAMING = {
   appName: 'Bible Reference',
@@ -28,7 +29,7 @@ export interface BibleReferencePluginSettings {
   referenceLinkPosition?: BibleVerseReferenceLinkPosition
   verseFormatting?: BibleVerseFormat
   verseNumberFormatting?: BibleVerseNumberFormat
-  collapsibleVerses?: boolean // this is binging to displayBibleIconPrefixAtHeader option
+  collapsibleVerses?: CollapsibleVerses // this is binging to displayBibleIconPrefixAtHeader option
   enableHyperlinking?: boolean
   showVerseTranslation?: boolean
   bookTagging?: boolean
@@ -51,7 +52,7 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   referenceLinkPosition: BibleVerseReferenceLinkPosition.Header,
   verseFormatting: BibleVerseFormat.SingleLine,
   verseNumberFormatting: BibleVerseNumberFormat.Period,
-  collapsibleVerses: false,
+  collapsibleVerses: CollapsibleVerses.Plus,
   enableHyperlinking: true,
   showVerseTranslation: true,
   bookTagging: false,

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -61,7 +61,7 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   bookBacklinking: OutgoingLinkPositionEnum.None,
   chapterBacklinking: OutgoingLinkPositionEnum.None,
   bibleVersionStatusIndicator: BibleVersionNameLengthEnum.Short,
-  displayBibleIconPrefixAtHeader: true,
+  displayBibleIconPrefixAtHeader: true
 }
 
 export const API_WAITING_LABEL = 'Loading...'

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,9 @@ export default class BibleReferencePlugin extends Plugin {
     this.addVerseOfDayInsertCommand()
     this.addVerseOfDayNoticeCommand()
 
+    // toggle bible icon prefix
+    this.toggleBibleIconPrefix()
+
     this.initStatusBarIndicator()
     EventStats.logRecord(this.settings.optOutToEvents)
   }
@@ -150,6 +153,19 @@ export default class BibleReferencePlugin extends Plugin {
           this.settings.optOutToEvents
         )
         editor.replaceSelection(vodSuggesting.allFormattedContent)
+      },
+    })
+  }
+
+  // create a hotkey that will toggle the "Show Bible Icon Prefix" setting called: "setUpBibleIconPrefixToggle" from the BibleReferenceSettingTab class
+
+  private toggleBibleIconPrefix() {
+    this.addCommand({
+      id: 'toggle-bible-icon-prefix',
+      name: 'Toggle Bible Icon Prefix',
+      callback: () => {
+        this.settings.displayBibleIconPrefixAtHeader = !this.settings.displayBibleIconPrefixAtHeader
+        this.saveSettings()
       },
     })
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,8 +157,6 @@ export default class BibleReferencePlugin extends Plugin {
     })
   }
 
-  // create a hotkey that will toggle the "Show Bible Icon Prefix" setting called: "setUpBibleIconPrefixToggle" from the BibleReferenceSettingTab class
-
   private toggleBibleIconPrefix() {
     this.addCommand({
       id: 'toggle-bible-icon-prefix',

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -4,6 +4,7 @@ import { BibleVerseNumberFormat } from '../data/BibleVerseNumberFormat'
 import { VerseReference } from '../utils/splitBibleReference'
 import { BibleVerseFormat } from '../data/BibleVerseFormat'
 import { IVerse } from '../interfaces/IVerse'
+import { CollapsibleVerses } from 'src/data/CollapsibleVerses'
 
 export abstract class BaseVerseFormatter {
   protected settings: BibleReferencePluginSettings
@@ -78,8 +79,16 @@ export abstract class BaseVerseFormatter {
     if (this.settings.displayBibleIconPrefixAtHeader) {
       head += '[!bible]'
 
-      if (this.settings?.collapsibleVerses) {
-        head += '+'
+      switch (this.settings?.collapsibleVerses) {
+        case CollapsibleVerses.Plus:
+          head += '+'
+          break
+        case CollapsibleVerses.Minus:
+          head += '-'
+          break
+        case CollapsibleVerses.None:
+          head += ''
+          break
       }
     }
 


### PR DESCRIPTION
**The culprit:**
![Obsidian_llgiQRjuIc](https://github.com/user-attachments/assets/7965f63d-0447-4d69-918b-b430d70d545d)

**The change made:**
![Obsidian_eQuqIFK6Rt](https://github.com/user-attachments/assets/f897850c-0e10-4c13-8521-44bd6ce8b8f4)

Notice the extra space that the extra `<br/>` tag makes when it is included?