### PR TITLE
add italic options for BibleVerseNumberFormat

### DIFF
--- a/src/data/BibleVerseNumberFormat.ts
+++ b/src/data/BibleVerseNumberFormat.ts
@@ -6,7 +6,9 @@ export enum BibleVerseNumberFormat {
   NumberOnly = '1 ',
   SuperScript = '^1',
   SuperScriptBold = '**^1**',
+  SuperScriptItalic = '*^1*',
   Bold = '**1**',
+  Italic = '*1*',
   None = 'None',
 }
 
@@ -40,8 +42,16 @@ export const BibleVerseNumberFormatCollection = [
     description: '**^1** (bolded superscript)',
   },
   {
+    name: BibleVerseNumberFormat.SuperScriptItalic,
+    description: '*^1* (italic superscript)',
+  },
+  {
     name: BibleVerseNumberFormat.Bold,
     description: '**1** (bold)',
+  },
+  {
+    name: BibleVerseNumberFormat.Italic,
+    description: '*1* (italic)',
   },
   {
     name: BibleVerseNumberFormat.None,

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -133,8 +133,14 @@ export abstract class BaseVerseFormatter {
       case BibleVerseNumberFormat.SuperScriptBold:
         verseNumberFormatted += '<sup> **' + verseNumber + '** </sup>'
         return verseNumberFormatted
+      case BibleVerseNumberFormat.SuperScriptItalic:
+        verseNumberFormatted += '<sup> *' + verseNumber + '* </sup>'
+        return verseNumberFormatted
       case BibleVerseNumberFormat.Bold:
         verseNumberFormatted += '**' + verseNumber + '** '
+        return verseNumberFormatted
+      case BibleVerseNumberFormat.Italic:
+        verseNumberFormatted += '*' + verseNumber + '* '
         return verseNumberFormatted
       case BibleVerseNumberFormat.None:
         verseNumberFormatted = ' '


### PR DESCRIPTION
## What does this PR do?
This PR simply adds two italic options to the BibleVerseNumberFormat choices.

## Why is this change needed?
Many users, myself included, have custom colors assigned to italics and bold, and an italics option for Bible verse numbers can very simply and efficiently enhance the aesthetics of any given Bible Reference.

## How was this tested?
Manual testing was used. This change did not alter any functionality, but merely added two additional options to the menu for potential use.