### PR TITLE
Add internally linked verse numbers to advanced options and italics

### DIFF
--- a/src/data/BibleVerseNumberFormat.ts
+++ b/src/data/BibleVerseNumberFormat.ts
@@ -6,7 +6,9 @@ export enum BibleVerseNumberFormat {
   NumberOnly = '1 ',
   SuperScript = '^1',
   SuperScriptBold = '**^1**',
+  SuperScriptItalic = '*^1*',
   Bold = '**1**',
+  Italic = '*1*',
   None = 'None',
 }
 
@@ -40,8 +42,16 @@ export const BibleVerseNumberFormatCollection = [
     description: '**^1** (bolded superscript)',
   },
   {
+    name: BibleVerseNumberFormat.SuperScriptItalic,
+    description: '*^1* (italic superscript)',
+  },
+  {
     name: BibleVerseNumberFormat.Bold,
     description: '**1** (bold)',
+  },
+  {
+    name: BibleVerseNumberFormat.Italic,
+    description: '*1* (italic)',
   },
   {
     name: BibleVerseNumberFormat.None,

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -43,6 +43,7 @@ export interface BibleReferencePluginSettings {
   advancedSettings?: boolean
   bibleVersionStatusIndicator?: BibleVersionNameLengthEnum
   displayBibleIconPrefixAtHeader?: boolean // this is binding to to header collapsible option
+  enableInternalLinking?: string
 }
 
 export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
@@ -62,6 +63,7 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   chapterBacklinking: OutgoingLinkPositionEnum.None,
   bibleVersionStatusIndicator: BibleVersionNameLengthEnum.Short,
   displayBibleIconPrefixAtHeader: true,
+  enableInternalLinking: 'None'
 }
 
 export const API_WAITING_LABEL = 'Loading...'

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -160,7 +160,31 @@ Obsidian Bible Reference  is proudly powered by
               )
             })
         )
-
+      new Setting(this.expertSettingContainer)
+        .setName('Add Internal Linking to the Verse Numbers')
+        .setDesc(
+          'Choose how verse numbers should link internally. ' +
+          'Warning: Links will only work if matching notes/block IDs exist in your vault.'
+        )
+        .addDropdown((dropdown) => {
+          dropdown
+            .addOption('None', 'None')
+            .addOption('[[Book Chapter#^Verse|Verse]]', '[[John 1#^1|1]]')
+            .addOption('[[Book Chapter#Verse|Verse]]', '[[John 1#1|1]]')
+            .addOption('[[Book Chapter:Verse|Verse]]', '[[John 1:1|1]]')
+            .setValue(this.plugin.settings.internalLinkingFormat || 'None')
+            .onChange(async (value) => {
+              this.plugin.settings.internalLinkingFormat = value;
+              await this.plugin.saveSettings();
+              new Notice('Internal Linking Format Updated');
+              EventStats.logSettingChange(
+              'changeInternalLinkingFormat',
+              { key: `internal-linking-${value}`, value: 1 },
+              this.plugin.settings.optOutToEvents
+            );
+          });
+          dropdown.selectEl.style.width = '200px';
+        });
       const getOutgoingLinkPosition = (
         linkingPostion: string | OutgoingLinkPositionEnum | undefined
       ) => {

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -109,39 +109,53 @@ export abstract class BaseVerseFormatter {
 
   protected abstract getVerseReferenceLink(): string
 
-  protected formatVerseNumber(verseNumber: number | string) {
-    let verseNumberFormatted = ''
+  protected getVerseLink(verseNumber: number): string {
+  const { bookName, chapterNumber } = this.verseReference;
+  const verseNumberLinkFormat = this.settings.internalLinkingFormat || 'None';
+  if (verseNumberLinkFormat === 'None') return '';
+  const verseNumStr = verseNumber.toString();
+  switch (verseNumberLinkFormat) {
+    case '[[Book Chapter#^Verse|Verse]]':
+      return `[[${bookName} ${chapterNumber}#^${verseNumStr}|${verseNumStr}]]`;
+    case '[[Book Chapter#Verse|Verse]]':
+      return `[[${bookName} ${chapterNumber}#${verseNumStr}|${verseNumStr}]]`;
+    case '[[Book Chapter:Verse|Verse]]':
+      return `[[${bookName} ${chapterNumber}:${verseNumStr}|${verseNumStr}]]`;
+    default:
+      return '';
+    }
+  }
+
+  protected formatVerseNumber(verseNumber: number | string): string {
+    const verseNumStr2 = verseNumber.toString();
+    const verseNumLink = this.getVerseLink(Number(verseNumber));
+    const verseNumberFormatted = verseNumLink || verseNumStr2;
+
     switch (this.settings.verseNumberFormatting) {
       case BibleVerseNumberFormat.Period:
-        verseNumberFormatted += verseNumber + '. '
-        return verseNumberFormatted
+        return verseNumberFormatted + '. ';
       case BibleVerseNumberFormat.PeriodParenthesis:
-        verseNumberFormatted += verseNumber + '.) '
-        return verseNumberFormatted
+        return verseNumberFormatted + '.) ';
       case BibleVerseNumberFormat.Parenthesis:
-        verseNumberFormatted += verseNumber + ') '
-        return verseNumberFormatted
+        return verseNumberFormatted + ') ';
       case BibleVerseNumberFormat.Dash:
-        verseNumberFormatted += verseNumber + ' - '
-        return verseNumberFormatted
+        return verseNumberFormatted + ' - ';
       case BibleVerseNumberFormat.NumberOnly:
-        verseNumberFormatted += verseNumber + ' '
-        return verseNumberFormatted
+        return verseNumberFormatted + ' ';
       case BibleVerseNumberFormat.SuperScript:
-        verseNumberFormatted += '<sup> ' + verseNumber + ' </sup>'
-        return verseNumberFormatted
+        return `<sup>${verseNumberFormatted}</sup> `;
       case BibleVerseNumberFormat.SuperScriptBold:
-        verseNumberFormatted += '<sup> **' + verseNumber + '** </sup>'
-        return verseNumberFormatted
+        return `<sup>**${verseNumberFormatted}**</sup> `;
+      case BibleVerseNumberFormat.SuperScriptItalic:
+        return `<sup>*${verseNumberFormatted}*</sup> `;
       case BibleVerseNumberFormat.Bold:
-        verseNumberFormatted += '**' + verseNumber + '** '
-        return verseNumberFormatted
+        return `**${verseNumberFormatted}** `;
+      case BibleVerseNumberFormat.Italic:
+        return `*${verseNumberFormatted}* `;
       case BibleVerseNumberFormat.None:
-        verseNumberFormatted = ' '
-        return verseNumberFormatted
+        return ' ';
       default:
-        verseNumberFormatted += verseNumber + '. '
-        return verseNumberFormatted
+        return verseNumberFormatted + '. ';
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?
This PR creates a new advanced option to internally link the verse numbers to a pre-existing Bible layout in the Obsidian Vault in 3 different formats.

## Why is this change needed?
Internal Linking: This feature allows for very quick and easy verse comparison if the reference text and the vault text is from two different versions. Additionally, it provides a simple way to access all other places a given verse is quoted in the vault even when nested within longer passages.

## How was this tested?
Manual testing was used, hopefully without error or oversight. :)