### PR TITLE
Adds an Advanced Option to Allow Alternative Reference Linking to Blue Letter Bible

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -35,6 +35,7 @@ export interface BibleReferencePluginSettings {
   chapterTagging?: boolean
   bookBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
   chapterBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
+  versionCodeBLB: string
 
   // add this to ui at some point todo
   enableBibleVerseLookupRibbon?: boolean
@@ -62,6 +63,7 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   chapterBacklinking: OutgoingLinkPositionEnum.None,
   bibleVersionStatusIndicator: BibleVersionNameLengthEnum.Short,
   displayBibleIconPrefixAtHeader: true,
+  versionCodeBLB: '',
 }
 
 export const API_WAITING_LABEL = 'Loading...'

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -125,8 +125,8 @@ Obsidian Bible Reference  is proudly powered by
 
   private displayExpertSettings(): void {
     if (this.expertSettingContainer) {
-      this.expertSettingContainer.empty()
-      this.expertSettingContainer.createEl('h2', { text: 'Expert Settings' })
+      this.expertSettingContainer.empty();
+      this.expertSettingContainer.createEl('h2', { text: 'Expert Settings' });
 
       new Setting(this.expertSettingContainer)
         .setName('Add a Book Tag')
@@ -212,7 +212,31 @@ Obsidian Bible Reference  is proudly powered by
           })
         })
 
-      this.setUpOptOutEventsOptions(this.expertSettingContainer)
+      new Setting(this.expertSettingContainer)
+        .setName('BLB Reference Alternative HyperLinking')
+        .setDesc(
+          'Adding a Blue Letter Bible Version Code in the box provided, will alternatively link the Bible Reference Hyperlink to BLB instead your default version already chosen above. Note: This effects only the link itself and not the bible passage text. If an invalid code is entered, the resulting link will be broken. Also, Hyperlinking must be enabled above and using this hinders the version from being displayed for the passage text even ifyou have that option selected.'
+        )
+        .setTooltip('Please make sure the BLB Version Code is accurate')
+        .addText((text) => {
+            text
+              .setPlaceholder('e.g., KJV')
+              .setValue(this.plugin.settings.versionCodeBLB || '')
+              .onChange(async (value) => {
+                this.plugin.settings.versionCodeBLB = value;
+                await this.plugin.saveSettings();
+                new Notice(`BLB Alternative Reference Link Version Code set to: ${value}`);
+                EventStats.logSettingChange(
+                  'setVersionCodeBLB',
+                  { key: `versionCodeBLB-${value}`, value: 1 },
+                  this.plugin.settings.optOutToEvents
+                );
+              });
+            if (!this.plugin.settings.enableHyperlinking) {
+              text.setDisabled(true);
+            }
+          });
+      this.setUpOptOutEventsOptions(this.expertSettingContainer);
     }
   }
 
@@ -403,6 +427,7 @@ Obsidian Bible Reference  is proudly powered by
             { key: `hyperlinking-${value}`, value: 1 },
             this.plugin.settings.optOutToEvents
           )
+          pluginEvent.trigger('bible-reference:settings:re-render', []);
         })
     })
   }

--- a/src/utils/referenceBLBAltLinking.ts
+++ b/src/utils/referenceBLBAltLinking.ts
@@ -1,0 +1,125 @@
+// utils/referenceBLBAltLinking.ts
+
+import { BibleReferencePluginSettings } from '../data/constants';
+import { VerseReference } from '../utils/splitBibleReference';
+
+/**
+ * Mapping of standard book names to Blue Letter Bible three-character codes.
+ */
+export const blbBookCodes: { [key: string]: string } = {
+  'Genesis': 'Gen',
+  'Exodus': 'Exo',
+  'Leviticus': 'Lev',
+  'Numbers': 'Num',
+  'Deuteronomy': 'Deu',
+  'Joshua': 'Jos',
+  'Judges': 'Jdg',
+  'Ruth': 'Rth',
+  '1 Samuel': '1Sa',
+  '2 Samuel': '2Sa',
+  '1 Kings': '1Ki',
+  '2 Kings': '2Ki',
+  '1 Chronicles': '1Ch',
+  '2 Chronicles': '2Ch',
+  'Ezra': 'Ezr',
+  'Nehemiah': 'Neh',
+  'Esther': 'Est',
+  'Job': 'Job',
+  'Psalms': 'Psa',
+  'Proverbs': 'Pro',
+  'Ecclesiastes': 'Ecc',
+  'Song of Solomon': 'Sng',
+  'Isaiah': 'Isa',
+  'Jeremiah': 'Jer',
+  'Lamentations': 'Lam',
+  'Ezekiel': 'Eze',
+  'Daniel': 'Dan',
+  'Hosea': 'Hos',
+  'Joel': 'Joe',
+  'Amos': 'Amo',
+  'Obadiah': 'Oba',
+  'Jonah': 'Jon',
+  'Micah': 'Mic',
+  'Nahum': 'Nah',
+  'Habakkuk': 'Hab',
+  'Zephaniah': 'Zep',
+  'Haggai': 'Hag',
+  'Zechariah': 'Zec',
+  'Malachi': 'Mal',
+  'Matthew': 'Mat',
+  'Mark': 'Mar',
+  'Luke': 'Luk',
+  'John': 'Jhn',
+  'Acts': 'Act',
+  'Romans': 'Rom',
+  '1 Corinthians': '1Co',
+  '2 Corinthians': '2Co',
+  'Galatians': 'Gal',
+  'Ephesians': 'Eph',
+  'Philippians': 'Php',
+  'Colossians': 'Col',
+  '1 Thessalonians': '1Th',
+  '2 Thessalonians': '2Th',
+  '1 Timothy': '1Ti',
+  '2 Timothy': '2Ti',
+  'Titus': 'Tit',
+  'Philemon': 'Phm',
+  'Hebrews': 'Heb',
+  'James': 'Jas',
+  '1 Peter': '1Pe',
+  '2 Peter': '2Pe',
+  '1 John': '1Jn',
+  '2 John': '2Jn',
+  '3 John': '3Jn',
+  'Jude': 'Jud',
+  'Revelation': 'Rev'
+};
+
+/**
+ * Generates a Blue Letter Bible URL for a given verse reference.
+ * @throws Error if the book name is not found in the mapping.
+ */
+export function getBLBUrl(
+  versionCode: string,
+  bookName: string,
+  chapterNumber: number,
+  verseNumber: number,
+  verseNumberEnd?: number
+): string {
+  const bookCode = blbBookCodes[bookName];
+  if (!bookCode) {
+    throw new Error(`Book code not found for ${bookName}`);
+  }
+  let url = `https://www.blueletterbible.org/${versionCode}/${bookCode}/${chapterNumber}/${verseNumber}`;
+  if (verseNumberEnd) {
+    url += `-${verseNumberEnd}`;
+  }
+  return url;
+}
+
+/**
+ * Generates a formatted BLB hyperlink for the verse reference.
+ * @param settings - The plugin settings containing versionCodeBLB.
+ * @param verseReference - The verse reference object with book, chapter, and verse details.
+ * @returns A Markdown link string or an empty string if there's an error.
+ */
+export function getBLBLink(
+  settings: BibleReferencePluginSettings,
+  verseReference: VerseReference
+): string {
+  const { bookName, chapterNumber, verseNumber, verseNumberEnd } = verseReference;
+  try {
+    const url = getBLBUrl(
+      settings.versionCodeBLB,
+      bookName,
+      chapterNumber,
+      verseNumber,
+      verseNumberEnd
+    );
+    const reference = `${bookName} ${chapterNumber}:${verseNumber}${verseNumberEnd ? `-${verseNumberEnd}` : ''}`;
+    return ` [${reference}](${url})`;
+  } catch (error) {
+    console.error('Error generating BLB URL:', error);
+    return ''; // Return empty string for broken link
+  }
+}

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -4,6 +4,7 @@ import { BibleVerseNumberFormat } from '../data/BibleVerseNumberFormat'
 import { VerseReference } from '../utils/splitBibleReference'
 import { BibleVerseFormat } from '../data/BibleVerseFormat'
 import { IVerse } from '../interfaces/IVerse'
+import { getBLBLink } from '../utils/referenceBLBAltLinking';
 
 export abstract class BaseVerseFormatter {
   protected settings: BibleReferencePluginSettings
@@ -88,10 +89,14 @@ export abstract class BaseVerseFormatter {
       this.settings.referenceLinkPosition ===
         BibleVerseReferenceLinkPosition.AllAbove
     ) {
-      head += this.getVerseReferenceLink()
+      // Conditional BLB link
+      if (this.settings.versionCodeBLB && this.settings.enableHyperlinking) {
+        head += getBLBLink(this.settings, this.verseReference);
+      } else {
+        head += this.getVerseReferenceLink();
+      }
     }
-
-    return head
+    return head;
   }
 
   protected get bottom(): string {
@@ -102,9 +107,15 @@ export abstract class BaseVerseFormatter {
       this.settings.referenceLinkPosition ===
         BibleVerseReferenceLinkPosition.AllAbove
     ) {
-      bottom += `> \n ${this.getVerseReferenceLink()}`
+      bottom += `> \n `;
+      // Conditional BLB link
+      if (this.settings.versionCodeBLB && this.settings.enableHyperlinking) {
+        bottom += getBLBLink(this.settings, this.verseReference);
+      } else {
+        bottom += this.getVerseReferenceLink();
+      }
     }
-    return bottom
+    return bottom;
   }
 
   protected abstract getVerseReferenceLink(): string


### PR DESCRIPTION
## What does this PR do?
Adds an Advanced Option to Allow Alternative Reference Linking to Blue Letter Bible.

## Why is this change needed?
I find Blue Letter Bible to be a fantastic resource for deeper analysis. By allowing an Advanced option to link directly there it enables a significant convenience. Additionally, it allows for the link to be configured to go to a different version or language, thereby further enhancing its usefulness on a practical basis. All of this and more is available with a loss of virtually nothing except the default link being replaced by a more robust one. Having said that, I must say the bolls link is quite beautiful!

## What is the downside?
As noted in the settings, the use of this feature as currently written sacrifices the Version Indicator in the title. 

## How was this tested?
Manual testing was used, hopefully no unintended consequences result from implementation. 