### PR TITLE
Add Internally Linked Verse Numbers to Advanced Options

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -35,6 +35,7 @@ export interface BibleReferencePluginSettings {
   chapterTagging?: boolean
   bookBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
   chapterBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
+  internalLinkingFormat: string // this is refering to internal link
   versionCodeBLB: string
 
   // add this to ui at some point todo
@@ -44,6 +45,7 @@ export interface BibleReferencePluginSettings {
   advancedSettings?: boolean
   bibleVersionStatusIndicator?: BibleVersionNameLengthEnum
   displayBibleIconPrefixAtHeader?: boolean // this is binding to to header collapsible option
+  enableInternalLinking?: string
 }
 
 export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
@@ -63,6 +65,8 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   chapterBacklinking: OutgoingLinkPositionEnum.None,
   bibleVersionStatusIndicator: BibleVersionNameLengthEnum.Short,
   displayBibleIconPrefixAtHeader: true,
+  internalLinkingFormat: 'None',
+  enableInternalLinking: 'None',
   versionCodeBLB: '',
 }
 

--- a/src/provider/EventStats.ts
+++ b/src/provider/EventStats.ts
@@ -30,6 +30,7 @@ const EVENTS = {
 
   errors: '0d3fad56-4293-4691-b810-9a32cd1f6117',
   setVersionCodeBLB: '0d3fad56-4293-4691-b810-9a32cd1f6118',
+  changeInternalLinkingFormat: '1236fb13-bbd3-4797-8e8d-e317fc0ad22c', // via npx uuid
 }
 
 type VerseLookUp = 'verseLookUp' | 'vodLookUp'
@@ -44,6 +45,7 @@ type SettingChange =
   | 'changeVerseFormatting'
   | 'others'
   | 'setVersionCodeBLB'
+  | 'changeInternalLinkingFormat'
 type EventsKeys = keyof typeof EVENTS
 type EventsValues = (typeof EVENTS)[EventsKeys]
 

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -240,6 +240,31 @@ Obsidian Bible Reference  is proudly powered by
             text.setDisabled(true)
           }
         })
+
+      new Setting(this.expertSettingContainer)
+        .setName('Add Internal Linking to the Verse Numbers')
+        .setDesc(
+          'Choose how verse numbers should link internally to match your system. ' +
+            'Warning: Links will only work if matching notes/block IDs exist in your vault.'
+        )
+        .addDropdown((dropdown) => {
+          dropdown
+            .addOption('None', 'None')
+            .addOption('[[Book Chapter#^Verse|Verse]]', '[[John 1#^1|1]]')
+            .addOption('[[Book Chapter#Verse|Verse]]', '[[John 1#1|1]]')
+            .addOption('[[Book Chapter.Verse|Verse]]', '[[John 1.1|1]]')
+            .setValue(this.plugin.settings.internalLinkingFormat || 'None')
+            .onChange(async (value) => {
+              this.plugin.settings.internalLinkingFormat = value
+              await this.plugin.saveSettings()
+              new Notice('Internal Linking Format Updated')
+              EventStats.logSettingChange(
+                'changeInternalLinkingFormat',
+                { key: `internal-linking-${value}`, value: 1 },
+                this.plugin.settings.optOutToEvents
+              )
+            })
+        })
       this.setUpOptOutEventsOptions(this.expertSettingContainer)
     }
   }
@@ -416,9 +441,9 @@ Obsidian Bible Reference  is proudly powered by
   private setUpHyperlinkingOptions(): void {
     const setting = new Setting(this.containerEl)
       .setName('Enable Hyperlinking')
-      .setDesc('Enable or disable hyperlinking in verses reference')
+      .setDesc('Enable or disable hyperlinking in the verses reference')
     setting.setTooltip(
-      'This will make the verse number clickable and will open the verse in the Bible app'
+      'This will make the verse number clickable and will open the passage for viewing.'
     )
     setting.addToggle((toggle) => {
       toggle

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -128,45 +128,53 @@ export abstract class BaseVerseFormatter {
 
   protected abstract getVerseReferenceLink(): string
 
-  protected formatVerseNumber(verseNumber: number | string) {
-    let verseNumberFormatted = ''
+  protected getVerseLink(verseNumber: number): string {
+    const { bookName, chapterNumber } = this.verseReference
+    const verseNumberLinkFormat = this.settings.internalLinkingFormat || 'None'
+    if (verseNumberLinkFormat === 'None') return ''
+    const verseNumStr = verseNumber.toString()
+    switch (verseNumberLinkFormat) {
+      case '[[Book Chapter#^Verse|Verse]]':
+        return `[[${bookName} ${chapterNumber}#^${verseNumStr}|${verseNumStr}]]`
+      case '[[Book Chapter#Verse|Verse]]':
+        return `[[${bookName} ${chapterNumber}#${verseNumStr}|${verseNumStr}]]`
+      case '[[Book Chapter.Verse|Verse]]':
+        return `[[${bookName} ${chapterNumber}.${verseNumStr}|${verseNumStr}]]`
+      default:
+        return ''
+    }
+  }
+
+  protected formatVerseNumber(verseNumber: number | string): string {
+    const verseNumStr2 = verseNumber.toString()
+    const verseNumLink = this.getVerseLink(Number(verseNumber))
+    const verseNumberFormatted = verseNumLink || verseNumStr2
+
     switch (this.settings.verseNumberFormatting) {
       case BibleVerseNumberFormat.Period:
-        verseNumberFormatted += verseNumber + '. '
-        return verseNumberFormatted
+        return verseNumberFormatted + '. '
       case BibleVerseNumberFormat.PeriodParenthesis:
-        verseNumberFormatted += verseNumber + '.) '
-        return verseNumberFormatted
+        return verseNumberFormatted + '.) '
       case BibleVerseNumberFormat.Parenthesis:
-        verseNumberFormatted += verseNumber + ') '
-        return verseNumberFormatted
+        return verseNumberFormatted + ') '
       case BibleVerseNumberFormat.Dash:
-        verseNumberFormatted += verseNumber + ' - '
-        return verseNumberFormatted
+        return verseNumberFormatted + ' - '
       case BibleVerseNumberFormat.NumberOnly:
-        verseNumberFormatted += verseNumber + ' '
-        return verseNumberFormatted
+        return verseNumberFormatted + ' '
       case BibleVerseNumberFormat.SuperScript:
-        verseNumberFormatted += '<sup> ' + verseNumber + ' </sup>'
-        return verseNumberFormatted
+        return `<sup>${verseNumberFormatted}</sup> `
       case BibleVerseNumberFormat.SuperScriptBold:
-        verseNumberFormatted += '<sup> **' + verseNumber + '** </sup>'
-        return verseNumberFormatted
+        return `<sup>**${verseNumberFormatted}**</sup> `
       case BibleVerseNumberFormat.SuperScriptItalic:
-        verseNumberFormatted += '<sup> *' + verseNumber + '* </sup>'
-        return verseNumberFormatted
+        return `<sup>*${verseNumberFormatted}*</sup> `
       case BibleVerseNumberFormat.Bold:
-        verseNumberFormatted += '**' + verseNumber + '** '
-        return verseNumberFormatted
+        return `**${verseNumberFormatted}** `
       case BibleVerseNumberFormat.Italic:
-        verseNumberFormatted += '*' + verseNumber + '* '
-        return verseNumberFormatted
+        return `*${verseNumberFormatted}* `
       case BibleVerseNumberFormat.None:
-        verseNumberFormatted = ' '
-        return verseNumberFormatted
+        return ' '
       default:
-        verseNumberFormatted += verseNumber + '. '
-        return verseNumberFormatted
+        return verseNumberFormatted + '. '
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?
This PR creates a new advanced option to internally link the verse numbers to a pre-existing Bible layout in the Obsidian Vault in 3 different formats.

## Why is this change needed?
Internal Linking: This feature allows for very quick and easy verse comparison if the reference text and the vault text is from two different versions. Additionally, it provides a simple way to access all other places a given verse is quoted in the vault even when nested within longer passages.

## How was this tested?
Manual testing was used, hopefully without error or oversight. :)