### PR TITLE
Feature Integration: Combined PR if You Happen to Appreciate all my Proposed Changes - Conflicts Resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ data.json
 .DS_Store
 .eslintignore
 .stignore
+
+# Exclude NixOS-specific residue
+flake.nix
+flake.lock
+/.direnv
+.envrc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,23 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "path": "/nix/store/g4ppspdl4fy7hnp4jgjl4ll03v7i08w3-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2021-2025 Akira Komamura
+# SPDX-License-Identifier: Unlicense
+{
+  inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    # Support a particular subset of the Nix systems
+    # systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      eachSystem =
+        f:
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.nodejs
+
+            # Alternatively, you can use a specific major version of Node.js
+
+            # pkgs.nodejs-22_x
+
+            # Use corepack to install npm/pnpm/yarn as specified in package.json
+            pkgs.corepack
+
+            # To install a specific alternative package manager directly,
+            # comment out one of these to use an alternative package manager.
+
+            # pkgs.yarn
+            # pkgs.pnpm
+            # pkgs.bun
+
+            # Required to enable the language server
+            pkgs.nodePackages.typescript
+            pkgs.nodePackages.typescript-language-server
+
+            # Python is required on NixOS if the dependencies require node-gyp
+
+            # pkgs.python3
+          ];
+        };
+      });
+    };
+}

--- a/src/data/BibleVerseNumberFormat.ts
+++ b/src/data/BibleVerseNumberFormat.ts
@@ -6,7 +6,9 @@ export enum BibleVerseNumberFormat {
   NumberOnly = '1 ',
   SuperScript = '^1',
   SuperScriptBold = '**^1**',
+  SuperScriptItalic = '*^1*',
   Bold = '**1**',
+  Italic = '*1*',
   None = 'None',
 }
 
@@ -40,8 +42,16 @@ export const BibleVerseNumberFormatCollection = [
     description: '**^1** (bolded superscript)',
   },
   {
+    name: BibleVerseNumberFormat.SuperScriptItalic,
+    description: '*^1* (italic superscript)',
+  },
+  {
     name: BibleVerseNumberFormat.Bold,
     description: '**1** (bold)',
+  },
+  {
+    name: BibleVerseNumberFormat.Italic,
+    description: '*1* (italic)',
   },
   {
     name: BibleVerseNumberFormat.None,

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -35,8 +35,7 @@ export interface BibleReferencePluginSettings {
   chapterTagging?: boolean
   bookBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
   chapterBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
-  versionCodeBLB: string
-
+  
   // add this to ui at some point todo
   enableBibleVerseLookupRibbon?: boolean
   optOutToEvents?: boolean
@@ -44,6 +43,8 @@ export interface BibleReferencePluginSettings {
   advancedSettings?: boolean
   bibleVersionStatusIndicator?: BibleVersionNameLengthEnum
   displayBibleIconPrefixAtHeader?: boolean // this is binding to to header collapsible option
+  enableInternalLinking?: string
+  versionCodeBLB: string
 }
 
 export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
@@ -63,7 +64,8 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   chapterBacklinking: OutgoingLinkPositionEnum.None,
   bibleVersionStatusIndicator: BibleVersionNameLengthEnum.Short,
   displayBibleIconPrefixAtHeader: true,
-  versionCodeBLB: '',
+  enableInternalLinking: 'None',
+  versionCodeBLB: ''
 }
 
 export const API_WAITING_LABEL = 'Loading...'

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -35,6 +35,7 @@ export interface BibleReferencePluginSettings {
   chapterTagging?: boolean
   bookBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
   chapterBacklinking?: OutgoingLinkPositionEnum // this is refering to outgoing link
+  versionCodeBLB: string
 
   // add this to ui at some point todo
   enableBibleVerseLookupRibbon?: boolean
@@ -62,6 +63,7 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   chapterBacklinking: OutgoingLinkPositionEnum.None,
   bibleVersionStatusIndicator: BibleVersionNameLengthEnum.Short,
   displayBibleIconPrefixAtHeader: true,
+  versionCodeBLB: '',
 }
 
 export const API_WAITING_LABEL = 'Loading...'

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -125,8 +125,8 @@ Obsidian Bible Reference  is proudly powered by
 
   private displayExpertSettings(): void {
     if (this.expertSettingContainer) {
-      this.expertSettingContainer.empty()
-      this.expertSettingContainer.createEl('h2', { text: 'Expert Settings' })
+      this.expertSettingContainer.empty();
+      this.expertSettingContainer.createEl('h2', { text: 'Expert Settings' });
 
       new Setting(this.expertSettingContainer)
         .setName('Add a Book Tag')
@@ -212,7 +212,31 @@ Obsidian Bible Reference  is proudly powered by
           })
         })
 
-      this.setUpOptOutEventsOptions(this.expertSettingContainer)
+      new Setting(this.expertSettingContainer)
+        .setName('BLB Reference Alternative HyperLinking')
+        .setDesc(
+          'Adding a Blue Letter Bible Version Code in the box provided, will alternatively link the Bible Reference Hyperlink to BLB instead your default version already chosen above. Note: This effects only the link itself and not the bible passage text. If an invalid code is entered, the resulting link will be broken. Also, Hyperlinking must be enabled above and using this hinders the version from being displayed for the passage text even ifyou have that option selected.'
+        )
+        .setTooltip('Please make sure the BLB Version Code is accurate')
+        .addText((text) => {
+            text
+              .setPlaceholder('e.g., KJV')
+              .setValue(this.plugin.settings.versionCodeBLB || '')
+              .onChange(async (value) => {
+                this.plugin.settings.versionCodeBLB = value;
+                await this.plugin.saveSettings();
+                new Notice(`BLB Alternative Reference Link Version Code set to: ${value}`);
+                EventStats.logSettingChange(
+                  'setVersionCodeBLB',
+                  { key: `versionCodeBLB-${value}`, value: 1 },
+                  this.plugin.settings.optOutToEvents
+                );
+              });
+            if (!this.plugin.settings.enableHyperlinking) {
+              text.setDisabled(true);
+            }
+          });
+      this.setUpOptOutEventsOptions(this.expertSettingContainer);
     }
   }
 
@@ -403,6 +427,7 @@ Obsidian Bible Reference  is proudly powered by
             { key: `hyperlinking-${value}`, value: 1 },
             this.plugin.settings.optOutToEvents
           )
+          pluginEvent.trigger('bible-reference:settings:re-render', []);
         })
     })
   }

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -160,7 +160,6 @@ Obsidian Bible Reference  is proudly powered by
               )
             })
         )
-
       const getOutgoingLinkPosition = (
         linkingPostion: string | OutgoingLinkPositionEnum | undefined
       ) => {
@@ -211,6 +210,31 @@ Obsidian Bible Reference  is proudly powered by
             await this.plugin.saveSettings()
           })
         })
+
+      new Setting(this.expertSettingContainer)
+        .setName('Add Internal Linking to the Verse Numbers')
+        .setDesc(
+          'Choose how verse numbers should link internally to match your system. ' +
+          'Warning: Links will only work if matching notes/block IDs exist in your vault.'
+        )
+        .addDropdown((dropdown) => {
+          dropdown
+            .addOption('None', 'None')
+            .addOption('[[Book Chapter#^Verse|Verse]]', '[[John 1#^1|1]]')
+            .addOption('[[Book Chapter#Verse|Verse]]', '[[John 1#1|1]]')
+            .addOption('[[Book Chapter.Verse|Verse]]', '[[John 1.1|1]]')
+            .setValue(this.plugin.settings.internalLinkingFormat || 'None')
+            .onChange(async (value) => {
+              this.plugin.settings.internalLinkingFormat = value;
+              await this.plugin.saveSettings();
+              new Notice('Internal Linking Format Updated');
+              EventStats.logSettingChange(
+              'changeInternalLinkingFormat',
+              { key: `internal-linking-${value}`, value: 1 },
+              this.plugin.settings.optOutToEvents
+            );
+          });
+        });
 
       new Setting(this.expertSettingContainer)
         .setName('BLB Reference Alternative HyperLinking')
@@ -412,9 +436,9 @@ Obsidian Bible Reference  is proudly powered by
   private setUpHyperlinkingOptions(): void {
     const setting = new Setting(this.containerEl)
       .setName('Enable Hyperlinking')
-      .setDesc('Enable or disable hyperlinking in verses reference')
+      .setDesc('Enable or disable hyperlinking in the verses reference')
     setting.setTooltip(
-      'This will make the verse number clickable and will open the verse in the Bible app'
+      'This will make the verse number clickable and will open the passage for viewing.'
     )
     setting.addToggle((toggle) => {
       toggle

--- a/src/utils/referenceBLBAltLinking.ts
+++ b/src/utils/referenceBLBAltLinking.ts
@@ -1,0 +1,125 @@
+// utils/referenceBLBAltLinking.ts
+
+import { BibleReferencePluginSettings } from '../data/constants';
+import { VerseReference } from '../utils/splitBibleReference';
+
+/**
+ * Mapping of standard book names to Blue Letter Bible three-character codes.
+ */
+export const blbBookCodes: { [key: string]: string } = {
+  'Genesis': 'Gen',
+  'Exodus': 'Exo',
+  'Leviticus': 'Lev',
+  'Numbers': 'Num',
+  'Deuteronomy': 'Deu',
+  'Joshua': 'Jos',
+  'Judges': 'Jdg',
+  'Ruth': 'Rth',
+  '1 Samuel': '1Sa',
+  '2 Samuel': '2Sa',
+  '1 Kings': '1Ki',
+  '2 Kings': '2Ki',
+  '1 Chronicles': '1Ch',
+  '2 Chronicles': '2Ch',
+  'Ezra': 'Ezr',
+  'Nehemiah': 'Neh',
+  'Esther': 'Est',
+  'Job': 'Job',
+  'Psalms': 'Psa',
+  'Proverbs': 'Pro',
+  'Ecclesiastes': 'Ecc',
+  'Song of Solomon': 'Sng',
+  'Isaiah': 'Isa',
+  'Jeremiah': 'Jer',
+  'Lamentations': 'Lam',
+  'Ezekiel': 'Eze',
+  'Daniel': 'Dan',
+  'Hosea': 'Hos',
+  'Joel': 'Joe',
+  'Amos': 'Amo',
+  'Obadiah': 'Oba',
+  'Jonah': 'Jon',
+  'Micah': 'Mic',
+  'Nahum': 'Nah',
+  'Habakkuk': 'Hab',
+  'Zephaniah': 'Zep',
+  'Haggai': 'Hag',
+  'Zechariah': 'Zec',
+  'Malachi': 'Mal',
+  'Matthew': 'Mat',
+  'Mark': 'Mar',
+  'Luke': 'Luk',
+  'John': 'Jhn',
+  'Acts': 'Act',
+  'Romans': 'Rom',
+  '1 Corinthians': '1Co',
+  '2 Corinthians': '2Co',
+  'Galatians': 'Gal',
+  'Ephesians': 'Eph',
+  'Philippians': 'Php',
+  'Colossians': 'Col',
+  '1 Thessalonians': '1Th',
+  '2 Thessalonians': '2Th',
+  '1 Timothy': '1Ti',
+  '2 Timothy': '2Ti',
+  'Titus': 'Tit',
+  'Philemon': 'Phm',
+  'Hebrews': 'Heb',
+  'James': 'Jas',
+  '1 Peter': '1Pe',
+  '2 Peter': '2Pe',
+  '1 John': '1Jn',
+  '2 John': '2Jn',
+  '3 John': '3Jn',
+  'Jude': 'Jud',
+  'Revelation': 'Rev'
+};
+
+/**
+ * Generates a Blue Letter Bible URL for a given verse reference.
+ * @throws Error if the book name is not found in the mapping.
+ */
+export function getBLBUrl(
+  versionCode: string,
+  bookName: string,
+  chapterNumber: number,
+  verseNumber: number,
+  verseNumberEnd?: number
+): string {
+  const bookCode = blbBookCodes[bookName];
+  if (!bookCode) {
+    throw new Error(`Book code not found for ${bookName}`);
+  }
+  let url = `https://www.blueletterbible.org/${versionCode}/${bookCode}/${chapterNumber}/${verseNumber}`;
+  if (verseNumberEnd) {
+    url += `-${verseNumberEnd}`;
+  }
+  return url;
+}
+
+/**
+ * Generates a formatted BLB hyperlink for the verse reference.
+ * @param settings - The plugin settings containing versionCodeBLB.
+ * @param verseReference - The verse reference object with book, chapter, and verse details.
+ * @returns A Markdown link string or an empty string if there's an error.
+ */
+export function getBLBLink(
+  settings: BibleReferencePluginSettings,
+  verseReference: VerseReference
+): string {
+  const { bookName, chapterNumber, verseNumber, verseNumberEnd } = verseReference;
+  try {
+    const url = getBLBUrl(
+      settings.versionCodeBLB,
+      bookName,
+      chapterNumber,
+      verseNumber,
+      verseNumberEnd
+    );
+    const reference = `${bookName} ${chapterNumber}:${verseNumber}${verseNumberEnd ? `-${verseNumberEnd}` : ''}`;
+    return ` [${reference}](${url})`;
+  } catch (error) {
+    console.error('Error generating BLB URL:', error);
+    return ''; // Return empty string for broken link
+  }
+}

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -120,45 +120,53 @@ export abstract class BaseVerseFormatter {
 
   protected abstract getVerseReferenceLink(): string
 
-  protected formatVerseNumber(verseNumber: number | string) {
-    let verseNumberFormatted = ''
+  protected getVerseLink(verseNumber: number): string {
+  const { bookName, chapterNumber } = this.verseReference;
+  const verseNumberLinkFormat = this.settings.internalLinkingFormat || 'None';
+  if (verseNumberLinkFormat === 'None') return '';
+  const verseNumStr = verseNumber.toString();
+  switch (verseNumberLinkFormat) {
+    case '[[Book Chapter#^Verse|Verse]]':
+      return `[[${bookName} ${chapterNumber}#^${verseNumStr}|${verseNumStr}]]`;
+    case '[[Book Chapter#Verse|Verse]]':
+      return `[[${bookName} ${chapterNumber}#${verseNumStr}|${verseNumStr}]]`;
+    case '[[Book Chapter.Verse|Verse]]':
+      return `[[${bookName} ${chapterNumber}.${verseNumStr}|${verseNumStr}]]`;
+    default:
+      return '';
+    }
+  }
+
+  protected formatVerseNumber(verseNumber: number | string): string {
+    const verseNumStr2 = verseNumber.toString();
+    const verseNumLink = this.getVerseLink(Number(verseNumber));
+    const verseNumberFormatted = verseNumLink || verseNumStr2;
+
     switch (this.settings.verseNumberFormatting) {
       case BibleVerseNumberFormat.Period:
-        verseNumberFormatted += verseNumber + '. '
-        return verseNumberFormatted
+        return verseNumberFormatted + '. ';
       case BibleVerseNumberFormat.PeriodParenthesis:
-        verseNumberFormatted += verseNumber + '.) '
-        return verseNumberFormatted
+        return verseNumberFormatted + '.) ';
       case BibleVerseNumberFormat.Parenthesis:
-        verseNumberFormatted += verseNumber + ') '
-        return verseNumberFormatted
+        return verseNumberFormatted + ') ';
       case BibleVerseNumberFormat.Dash:
-        verseNumberFormatted += verseNumber + ' - '
-        return verseNumberFormatted
+        return verseNumberFormatted + ' - ';
       case BibleVerseNumberFormat.NumberOnly:
-        verseNumberFormatted += verseNumber + ' '
-        return verseNumberFormatted
+        return verseNumberFormatted + ' ';
       case BibleVerseNumberFormat.SuperScript:
-        verseNumberFormatted += '<sup> ' + verseNumber + ' </sup>'
-        return verseNumberFormatted
+        return `<sup>${verseNumberFormatted}</sup> `;
       case BibleVerseNumberFormat.SuperScriptBold:
-        verseNumberFormatted += '<sup> **' + verseNumber + '** </sup>'
-        return verseNumberFormatted
+        return `<sup>**${verseNumberFormatted}**</sup> `;
       case BibleVerseNumberFormat.SuperScriptItalic:
-        verseNumberFormatted += '<sup> *' + verseNumber + '* </sup>'
-        return verseNumberFormatted
+        return `<sup>*${verseNumberFormatted}*</sup> `;
       case BibleVerseNumberFormat.Bold:
-        verseNumberFormatted += '**' + verseNumber + '** '
-        return verseNumberFormatted
+        return `**${verseNumberFormatted}** `;
       case BibleVerseNumberFormat.Italic:
-        verseNumberFormatted += '*' + verseNumber + '* '
-        return verseNumberFormatted
+        return `*${verseNumberFormatted}* `;
       case BibleVerseNumberFormat.None:
-        verseNumberFormatted = ' '
-        return verseNumberFormatted
+        return ' ';
       default:
-        verseNumberFormatted += verseNumber + '. '
-        return verseNumberFormatted
+        return verseNumberFormatted + '. ';
     }
   }
 }

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -4,6 +4,7 @@ import { BibleVerseNumberFormat } from '../data/BibleVerseNumberFormat'
 import { VerseReference } from '../utils/splitBibleReference'
 import { BibleVerseFormat } from '../data/BibleVerseFormat'
 import { IVerse } from '../interfaces/IVerse'
+import { getBLBLink } from '../utils/referenceBLBAltLinking';
 
 export abstract class BaseVerseFormatter {
   protected settings: BibleReferencePluginSettings
@@ -88,10 +89,14 @@ export abstract class BaseVerseFormatter {
       this.settings.referenceLinkPosition ===
         BibleVerseReferenceLinkPosition.AllAbove
     ) {
-      head += this.getVerseReferenceLink()
+      // Conditional BLB link
+      if (this.settings.versionCodeBLB && this.settings.enableHyperlinking) {
+        head += getBLBLink(this.settings, this.verseReference);
+      } else {
+        head += this.getVerseReferenceLink();
+      }
     }
-
-    return head
+    return head;
   }
 
   protected get bottom(): string {
@@ -102,9 +107,15 @@ export abstract class BaseVerseFormatter {
       this.settings.referenceLinkPosition ===
         BibleVerseReferenceLinkPosition.AllAbove
     ) {
-      bottom += `> \n ${this.getVerseReferenceLink()}`
+      bottom += `> \n `;
+      // Conditional BLB link
+      if (this.settings.versionCodeBLB && this.settings.enableHyperlinking) {
+        bottom += getBLBLink(this.settings, this.verseReference);
+      } else {
+        bottom += this.getVerseReferenceLink();
+      }
     }
-    return bottom
+    return bottom;
   }
 
   protected abstract getVerseReferenceLink(): string

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -133,8 +133,14 @@ export abstract class BaseVerseFormatter {
       case BibleVerseNumberFormat.SuperScriptBold:
         verseNumberFormatted += '<sup> **' + verseNumber + '** </sup>'
         return verseNumberFormatted
+      case BibleVerseNumberFormat.SuperScriptItalic:
+        verseNumberFormatted += '<sup> *' + verseNumber + '* </sup>'
+        return verseNumberFormatted
       case BibleVerseNumberFormat.Bold:
         verseNumberFormatted += '**' + verseNumber + '** '
+        return verseNumberFormatted
+      case BibleVerseNumberFormat.Italic:
+        verseNumberFormatted += '*' + verseNumber + '* '
         return verseNumberFormatted
       case BibleVerseNumberFormat.None:
         verseNumberFormatted = ' '


### PR DESCRIPTION
## Thank You!

This has recreated my favorite reference method that I used to have set up on my Mac before switching to Linux/NixOS. If you choose to integrate these, things will work again from your native plugin just like they do and did before on my machine and I loved it! 

And, thanks to your plugin, things are far less fragile than they used to be. 

(My previous Mac-based system put everything together via Macro.)

## All three PRs are included in this one, with conflicts already resolved.
1. [Add italic options for BibleVerseNumberFormat #263](https://github.com/tim-hub/obsidian-bible-reference/pull/263)
2. [Adds an Advanced Option to Allow Alternative Reference Linking to Blue Letter Bible #265](https://github.com/tim-hub/obsidian-bible-reference/pull/265)
3. [Add Internally Linked Verse Numbers to Advanced Options #266](https://github.com/tim-hub/obsidian-bible-reference/pull/266)

I'm new to this and these PRs are my first PRs ever and this is my first time modifying a plugin! I hope that does scare you, but thank you for giving these PRs consideration!

## Great job on everything!
Please forgive my newbieness and any breaches of protocol.

(like the Nix parts that snuck in there because the merge wouldn't obey otherwise. I'm still learning GitHub.)