### PR TITLE
fix(blb): fix Psalms lookup error and update NIV URL format

### DIFF
--- a/src/data/abbreviations.ts
+++ b/src/data/abbreviations.ts
@@ -513,6 +513,7 @@ export const BLB_BOOK_CODES: { [key: string]: string } = {
   Esther: 'Est',
   Job: 'Job',
   Psalms: 'Psa',
+  Psalm: 'Psa',
   Proverbs: 'Pro',
   Ecclesiastes: 'Ecc',
   'Song of Solomon': 'Sng',

--- a/src/utils/referenceBLBAltLinking.test.ts
+++ b/src/utils/referenceBLBAltLinking.test.ts
@@ -1,0 +1,29 @@
+import { getBLBUrl } from './referenceBLBAltLinking'
+
+describe('getBLBUrl', () => {
+  test('generates correct URL for Psalms (plural)', () => {
+    const url = getBLBUrl('KJV', 'Psalms', 23, 1)
+    expect(url).toBe('https://www.blueletterbible.org/kjv/psa/23/1/')
+  })
+
+  test('generates correct URL for Psalm (singular)', () => {
+    const url = getBLBUrl('KJV', 'Psalm', 23, 1)
+    expect(url).toBe('https://www.blueletterbible.org/kjv/psa/23/1/')
+  })
+
+  test('generates correct URL for niv2011 (maps to niv)', () => {
+    const url = getBLBUrl('niv2011', 'Psalm', 23, 1)
+    expect(url).toBe('https://www.blueletterbible.org/niv/psa/23/1/')
+  })
+
+  test('generates correct URL with verse range', () => {
+    const url = getBLBUrl('KJV', 'Psalm', 23, 1, 6)
+    expect(url).toBe('https://www.blueletterbible.org/kjv/psa/23/1-6/')
+  })
+
+  test('throws error for unknown book', () => {
+    expect(() => getBLBUrl('KJV', 'UnknownBook', 1, 1)).toThrow(
+      'Book code not found for UnknownBook'
+    )
+  })
+})

--- a/src/utils/referenceBLBAltLinking.ts
+++ b/src/utils/referenceBLBAltLinking.ts
@@ -17,9 +17,16 @@ export function getBLBUrl(
   if (!bookCode) {
     throw new Error(`Book code not found for ${bookName}`)
   }
-  let url = `https://www.blueletterbible.org/${versionCode}/${bookCode}/${chapterNumber}/${verseNumber}`
+
+  // Map internal version keys to BLB version codes
+  let blbVersion = versionCode.toLowerCase()
+  if (blbVersion === 'niv2011') {
+    blbVersion = 'niv'
+  }
+
+  let url = `https://www.blueletterbible.org/${blbVersion}/${bookCode.toLowerCase()}/${chapterNumber}/${verseNumber}`
   if (verseNumberEnd) {
     url += `-${verseNumberEnd}`
   }
-  return url
+  return url + '/'
 }


### PR DESCRIPTION
## Walkthrough: Blue Letter Bible Psalms Fix & URL Formatting

I have fixed the issue https://github.com/tim-hub/obsidian-bible-reference/issues/300 where querying *Psalms* with the Blue Letter Bible (BLB) setting enabled caused an error, and I updated the BLB URL format to match their specific requirements.

---

### Changes Made

### 1. Data Mapping Update

In `src/data/abbreviations.ts`, I added *Psalm* (singular) to the `BLB_BOOK_CODES` mapping. This ensures that lookups succeed regardless of whether the plural or singular form is used.

```diff
   Esther: 'Est',
   Job: 'Job',
   Psalms: 'Psa',
+  Psalm: 'Psa',
   Proverbs: 'Pro',

```

### 2. URL Generation Logic

In `src/utils/referenceBLBAltLinking.ts`, I updated the `getBLBUrl` function to perform the following:

* Map the internal `niv2011` key to the BLB-compatible `niv`.
* Convert both the version code and book code to lowercase.
* Add a trailing slash to the end of the URL.

```typescript
// Map internal version keys to BLB version codes
  let blbVersion = versionCode.toLowerCase()
  if (blbVersion === 'niv2011') {
    blbVersion = 'niv'
  }

  let url = `https://www.blueletterbible.org/${blbVersion}/${bookCode.toLowerCase()}/${chapterNumber}/${verseNumber}`
  if (verseNumberEnd) {
    url += `-${verseNumberEnd}`
  }
  return url + '/'

```

### 3. Automated Testing

I created a new test file `src/utils/referenceBLBAltLinking.test.ts` to verify the fix and ensure future regressions are caught.

---

### Verification Results

### Tests Passed

I ran the tests using `npx jest src/utils/referenceBLBAltLinking.test.ts` and all cases passed:

* **✓** generates correct URL for Psalms (plural)
* **✓** generates correct URL for Psalm (singular)
* **✓** generates correct URL for niv2011 (maps to niv)
* **✓** generates correct URL with verse range
* **✓** throws error for unknown book