### PR TITLE
fix: line break in cross-chapter and skipped verse formatting

### DIFF
--- a/src/verse/BaseVerseFormatter.test.ts
+++ b/src/verse/BaseVerseFormatter.test.ts
@@ -48,7 +48,7 @@ describe('BaseVerseFormatter', () => {
       { book_id: 'John', book_name: 'John', chapter: 4, verse: 1, text: 'v1' },
     ]
     const formatter = new MockFormatter(settings, verseReference, verses)
-    const expected = '> 36. v36\n> ---\n> 4\n> ---\n> 1. v1'
+    const expected = '> 36. v36\n>\n> ---\n> 4\n> ---\n> 1. v1'
     expect(formatter.bodyContent).toBe(expected)
   })
 
@@ -76,7 +76,7 @@ describe('BaseVerseFormatter', () => {
       { book_id: 'John', book_name: 'John', chapter: 4, verse: 1, text: 'v1' },
     ]
     const formatter = new MockFormatter(settings, verseReference, verses)
-    const expected = '> 36. v36\n> ---\n> 1. v1'
+    const expected = '> 36. v36\n>\n> ---\n> 1. v1'
     expect(formatter.bodyContent).toBe(expected)
   })
 
@@ -133,7 +133,7 @@ describe('BaseVerseFormatter', () => {
       },
     ]
     const formatter = new MockFormatter(settings, verseReference, verses)
-    const expected = '> 16. v16\n> ---\n> 19. v19'
+    const expected = '> 16. v16\n>\n> ---\n> 19. v19'
     expect(formatter.bodyContent).toBe(expected)
   })
 

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -70,14 +70,14 @@ export abstract class BaseVerseFormatter {
           if (this.settings?.verseFormatting === BibleVerseFormat.Paragraph) {
             text = text.trim() + `\n>\n> ---\n> ${verse.chapter}\n> ---\n>`
           } else {
-            text += `> ---\n> ${verse.chapter}\n> ---\n`
+            text += `>\n> ---\n> ${verse.chapter}\n> ---\n`
           }
         } else {
           const separator = `---`
           if (this.settings?.verseFormatting === BibleVerseFormat.Paragraph) {
             text = text.trim() + `\n>\n> ${separator}\n>`
           } else {
-            text += `> ${separator}\n`
+            text += `>\n> ${separator}\n`
           }
         }
       } else if (
@@ -93,7 +93,7 @@ export abstract class BaseVerseFormatter {
         if (this.settings?.verseFormatting === BibleVerseFormat.Paragraph) {
           text = text.trim() + `\n>\n> ${separator}\n>`
         } else {
-          text += `> ${separator}\n`
+          text += `>\n> ${separator}\n`
         }
       }
 


### PR DESCRIPTION
### Description

Fixed a visual bug where `---` separators in cross-chapter or skipped verse formatting caused the preceding line to be interpreted as a Markdown heading. This addresses issue #317 

---

### Changes Made

#### [Component] Verse Formatting Logic

**File:** `BaseVerseFormatter.ts`

Added a blank line (`>\n`) before separators in *SingleLine* (list) mode:

* Before chapter separators (with or without chapter numbers).
* Before verse gap separators.

This ensures Markdown correctly renders the separator without affecting the formatting of the preceding verse text.

### Verification Results

#### Automated Tests

All tests passed, including the updated unit tests in `BaseVerseFormatter.test.ts`.

* **Test Suites:** 10 passed, 10 total
* **Tests:** 99 passed, 99 total
* **Snapshots:** 0 total
* **Time:** 0.413 s

#### Updated Test Cases

The following test cases in `BaseVerseFormatter.test.ts` now verify the new format:

* *should add separators for chapter changes in list mode (default: with chapter number)*
* *should add separators for chapter changes in list mode without chapter number when disabled*
* *should add separators for verse gaps in same chapter (Single Line)*
