### PR TITLE
feat: automatically add newline when reference is at bottom

### DIFF
--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -597,6 +597,7 @@ Obsidian Bible Reference  is proudly powered by
           })
       })
   }
+
   private setUpBibleIconPrefixToggle(): void {
     new Setting(this.containerEl)
       .setName('Show Bible Icon Prefix "[!Bible]" *')

--- a/src/verse/BaseVerseFormatter.test.ts
+++ b/src/verse/BaseVerseFormatter.test.ts
@@ -8,6 +8,7 @@ import { BibleVerseFormat } from '../data/BibleVerseFormat'
 import { BibleVerseNumberFormat } from '../data/BibleVerseNumberFormat'
 import { BibleVerseSegmentSeparatorFormat } from '../data/BibleVerseSegmentSeparatorFormat'
 import { IVerse } from '../interfaces/IVerse'
+import { BibleVerseReferenceLinkPosition } from '../data/BibleVerseReferenceLinkPosition'
 
 class MockFormatter extends BaseVerseFormatter {
   constructor(
@@ -170,5 +171,79 @@ describe('BaseVerseFormatter', () => {
     const formatter = new MockFormatter(settings, verseReference, verses)
     const expected = '> 16. v16\n>\n> ---\n> 19. v19'
     expect(formatter.bodyContent).toBe(expected)
+  })
+
+  it('should add extra newline when position is Bottom', () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      referenceLinkPosition: BibleVerseReferenceLinkPosition.Bottom,
+    }
+    const verseReference: VerseReference = {
+      bookName: 'John',
+      chapterNumber: 3,
+      verseNumber: 16,
+      ranges: [{ chapterNumber: 3, verseNumber: 16 }],
+    }
+    const verses = [
+      {
+        book_id: 'John',
+        book_name: 'John',
+        chapter: 3,
+        verse: 16,
+        text: 'v16',
+      },
+    ]
+    const formatter = new MockFormatter(settings, verseReference, verses)
+    expect(formatter.allFormattedContent.endsWith('\n')).toBe(true)
+    expect(formatter.allFormattedContent.endsWith('\n\n')).toBe(false)
+  })
+
+  it('should NOT add extra newline when position is Header', () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      referenceLinkPosition: BibleVerseReferenceLinkPosition.Header,
+    }
+    const verseReference: VerseReference = {
+      bookName: 'John',
+      chapterNumber: 3,
+      verseNumber: 16,
+      ranges: [{ chapterNumber: 3, verseNumber: 16 }],
+    }
+    const verses = [
+      {
+        book_id: 'John',
+        book_name: 'John',
+        chapter: 3,
+        verse: 16,
+        text: 'v16',
+      },
+    ]
+    const formatter = new MockFormatter(settings, verseReference, verses)
+    expect(formatter.allFormattedContent.endsWith('\n')).toBe(false)
+  })
+
+  it('should add extra newline when position is Both', () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      referenceLinkPosition: BibleVerseReferenceLinkPosition.AllAbove,
+    }
+    const verseReference: VerseReference = {
+      bookName: 'John',
+      chapterNumber: 3,
+      verseNumber: 16,
+      ranges: [{ chapterNumber: 3, verseNumber: 16 }],
+    }
+    const verses = [
+      {
+        book_id: 'John',
+        book_name: 'John',
+        chapter: 3,
+        verse: 16,
+        text: 'v16',
+      },
+    ]
+    const formatter = new MockFormatter(settings, verseReference, verses)
+    expect(formatter.allFormattedContent.endsWith('\n')).toBe(true)
+    expect(formatter.allFormattedContent.endsWith('\n\n')).toBe(false)
   })
 })

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -41,7 +41,17 @@ export abstract class BaseVerseFormatter {
     if (!this.verses?.length) {
       console.error('No verses found')
     }
-    return [this.head, this.bodyContent, this.bottom].join('\n')
+    const parts = [this.head, this.bodyContent, this.bottom].filter(
+      (p) => p !== ''
+    )
+    const content = parts.join('\n')
+    const shouldAddNewLine =
+      this.settings.referenceLinkPosition ===
+        BibleVerseReferenceLinkPosition.Bottom ||
+      this.settings.referenceLinkPosition ===
+        BibleVerseReferenceLinkPosition.AllAbove
+
+    return shouldAddNewLine ? content + '\n' : content
   }
 
   public get bodyContent(): string {


### PR DESCRIPTION
Addresses https://github.com/tim-hub/obsidian-bible-reference/issues/319

When user uses reference at bottom or "header and bottom" setting, then the extra new line at the bottom is missing. If a user types immediately, then the bible callout is inadvertently continued. This fixes the problem

<img width="987" height="778" alt="image" src="https://github.com/user-attachments/assets/56762059-8c65-49d9-8dbb-332e396ac61e" />
