### PR TITLE
Add route.bible as a reference link source

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 You can also get a "verse of the day" by typing `--vod`.
 
-When hyperlinking is enabled, the generated verse reference links can target Original, Blue Letter Bible, Bible Gateway, Logos, or Route.Bible.
+When hyperlinking is enabled, the generated verse reference links can target Original, Blue Letter Bible, Bible Gateway, Logos, or route.bible.
 
 > Read more about [How to use](https://github.com/tim-hub/obsidian-bible-reference/blob/master/docs/howto.md)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 
 You can also get a "verse of the day" by typing `--vod`.
 
+When hyperlinking is enabled, the generated verse reference links can target Original, Blue Letter Bible, Bible Gateway, Logos, or Route.Bible.
+
 > Read more about [How to use](https://github.com/tim-hub/obsidian-bible-reference/blob/master/docs/howto.md)
 
 > On iOS devices, there is a known issue about conflict between `Smart Punctuation` and double hyphens `--`.

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -52,7 +52,12 @@ export interface BibleReferencePluginSettings {
   displayBibleIconPrefixAtHeader?: boolean // this is binding to to header collapsible option
   enableInternalLinking?: string
   logosFallbackVersion?: string
-  sourceOfReference?: 'original' | 'blb' | 'biblegateway' | 'logos'
+  sourceOfReference?:
+    | 'original'
+    | 'blb'
+    | 'biblegateway'
+    | 'logos'
+    | 'routebible'
 }
 
 export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -466,7 +466,7 @@ Obsidian Bible Reference  is proudly powered by
     const setting = new Setting(this.containerEl)
       .setName('Reference Link Source')
       .setDesc(
-        'Choose the source for verse reference links: Original (API provider), Blue Letter Bible, Bible Gateway, Logos, or Route.Bible'
+        'Choose the source for verse reference links: Original (API provider), Blue Letter Bible, Bible Gateway, Logos, or route.bible'
       )
     setting.setTooltip(
       'Select which service to use for generating verse reference links. This only applies when hyperlinking is enabled.'
@@ -476,7 +476,7 @@ Obsidian Bible Reference  is proudly powered by
       dropdown.addOption('blb', 'Blue Letter Bible (BLB)')
       dropdown.addOption('biblegateway', 'Bible Gateway')
       dropdown.addOption('logos', 'Logos')
-      dropdown.addOption('routebible', 'Route.Bible')
+      dropdown.addOption('routebible', 'route.bible')
       dropdown.setValue(
         this.plugin.settings.sourceOfReference || 'biblegateway'
       )

--- a/src/ui/BibleReferenceSettingTab.ts
+++ b/src/ui/BibleReferenceSettingTab.ts
@@ -466,7 +466,7 @@ Obsidian Bible Reference  is proudly powered by
     const setting = new Setting(this.containerEl)
       .setName('Reference Link Source')
       .setDesc(
-        'Choose the source for verse reference links: Original (API provider), Blue Letter Bible, Bible Gateway, or Logos'
+        'Choose the source for verse reference links: Original (API provider), Blue Letter Bible, Bible Gateway, Logos, or Route.Bible'
       )
     setting.setTooltip(
       'Select which service to use for generating verse reference links. This only applies when hyperlinking is enabled.'
@@ -476,7 +476,10 @@ Obsidian Bible Reference  is proudly powered by
       dropdown.addOption('blb', 'Blue Letter Bible (BLB)')
       dropdown.addOption('biblegateway', 'Bible Gateway')
       dropdown.addOption('logos', 'Logos')
-      dropdown.setValue(this.plugin.settings.sourceOfReference || 'original')
+      dropdown.addOption('routebible', 'Route.Bible')
+      dropdown.setValue(
+        this.plugin.settings.sourceOfReference || 'biblegateway'
+      )
       if (!this.plugin.settings?.enableHyperlinking) {
         dropdown.setDisabled(true)
       }
@@ -486,6 +489,7 @@ Obsidian Bible Reference  is proudly powered by
           | 'blb'
           | 'biblegateway'
           | 'logos'
+          | 'routebible'
         this.updateLogosFallbackVisibility()
         await this.plugin.saveSettings()
         pluginEvent.trigger('bible-reference:settings:re-render', [])

--- a/src/utils/referenceRouteBibleLinking.test.ts
+++ b/src/utils/referenceRouteBibleLinking.test.ts
@@ -5,7 +5,7 @@ describe('getRouteBibleUrl', () => {
     const url = getRouteBibleUrl('John 3:16', 'kjv')
 
     expect(url).toBe(
-      'https://route.bible/?q=John+3%3A16&v=KJV&src=obsidian_bible_reference&utm_source=obsidian_bible_reference&utm_medium=obsidian_plugin'
+      'https://route.bible/?q=John+3%3A16&v=KJV&src=obsidian_bible_reference&utm_source=obsidian_bible_reference&utm_medium=obsidian_plugin&utm_campaign=reference_link_source'
     )
   })
 

--- a/src/utils/referenceRouteBibleLinking.test.ts
+++ b/src/utils/referenceRouteBibleLinking.test.ts
@@ -1,0 +1,25 @@
+import { getRouteBibleUrl } from './referenceRouteBibleLinking'
+
+describe('getRouteBibleUrl', () => {
+  test('generates a Route.Bible URL for a single verse', () => {
+    const url = getRouteBibleUrl('John 3:16', 'kjv')
+
+    expect(url).toBe(
+      'https://route.bible/?q=John+3%3A16&v=KJV&src=obsidian_bible_reference&utm_source=obsidian_bible_reference&utm_medium=obsidian_plugin'
+    )
+  })
+
+  test('preserves same-chapter ranges in q', () => {
+    const url = getRouteBibleUrl('Romans 8:28-30', 'esv')
+
+    expect(url).toContain('q=Romans+8%3A28-30')
+    expect(url).toContain('v=ESV')
+  })
+
+  test('preserves cross-chapter references in q', () => {
+    const url = getRouteBibleUrl('Hebrews 9:1-10:14', 'niv')
+
+    expect(url).toContain('q=Hebrews+9%3A1-10%3A14')
+    expect(url).toContain('v=NIV')
+  })
+})

--- a/src/utils/referenceRouteBibleLinking.test.ts
+++ b/src/utils/referenceRouteBibleLinking.test.ts
@@ -1,7 +1,7 @@
 import { getRouteBibleUrl } from './referenceRouteBibleLinking'
 
 describe('getRouteBibleUrl', () => {
-  test('generates a Route.Bible URL for a single verse', () => {
+  test('generates a route.bible URL for a single verse', () => {
     const url = getRouteBibleUrl('John 3:16', 'kjv')
 
     expect(url).toBe(

--- a/src/utils/referenceRouteBibleLinking.ts
+++ b/src/utils/referenceRouteBibleLinking.ts
@@ -4,10 +4,14 @@ export function getRouteBibleUrl(
   options: {
     baseUrl?: string
     sourceTag?: string
+    mediumTag?: string
+    campaignTag?: string
   } = {}
 ): string {
   const baseUrl = options.baseUrl || 'https://route.bible/'
   const sourceTag = options.sourceTag || 'obsidian_bible_reference'
+  const mediumTag = options.mediumTag || 'obsidian_plugin'
+  const campaignTag = options.campaignTag || 'reference_link_source'
   const url = new URL('/', baseUrl)
 
   url.searchParams.set('q', referenceLabel)
@@ -19,7 +23,8 @@ export function getRouteBibleUrl(
 
   url.searchParams.set('src', sourceTag)
   url.searchParams.set('utm_source', sourceTag)
-  url.searchParams.set('utm_medium', 'obsidian_plugin')
+  url.searchParams.set('utm_medium', mediumTag)
+  url.searchParams.set('utm_campaign', campaignTag)
 
   return url.toString()
 }

--- a/src/utils/referenceRouteBibleLinking.ts
+++ b/src/utils/referenceRouteBibleLinking.ts
@@ -1,0 +1,25 @@
+export function getRouteBibleUrl(
+  referenceLabel: string,
+  versionKey: string,
+  options: {
+    baseUrl?: string
+    sourceTag?: string
+  } = {}
+): string {
+  const baseUrl = options.baseUrl || 'https://route.bible/'
+  const sourceTag = options.sourceTag || 'obsidian_bible_reference'
+  const url = new URL('/', baseUrl)
+
+  url.searchParams.set('q', referenceLabel)
+
+  const normalizedVersion = versionKey.trim().toUpperCase()
+  if (normalizedVersion) {
+    url.searchParams.set('v', normalizedVersion)
+  }
+
+  url.searchParams.set('src', sourceTag)
+  url.searchParams.set('utm_source', sourceTag)
+  url.searchParams.set('utm_medium', 'obsidian_plugin')
+
+  return url.toString()
+}

--- a/src/verse/VerseSuggesting.referenceLink.test.ts
+++ b/src/verse/VerseSuggesting.referenceLink.test.ts
@@ -44,7 +44,7 @@ describe('VerseSuggesting reference link sources', () => {
     })
 
     expect(suggesting.getReferenceUrl()).toBe(
-      'https://route.bible/?q=John+3%3A16&v=KJV&src=obsidian_bible_reference&utm_source=obsidian_bible_reference&utm_medium=obsidian_plugin'
+      'https://route.bible/?q=John+3%3A16&v=KJV&src=obsidian_bible_reference&utm_source=obsidian_bible_reference&utm_medium=obsidian_plugin&utm_campaign=reference_link_source'
     )
   })
 

--- a/src/verse/VerseSuggesting.referenceLink.test.ts
+++ b/src/verse/VerseSuggesting.referenceLink.test.ts
@@ -37,7 +37,7 @@ describe('VerseSuggesting reference link sources', () => {
       verseNumberEndChapter
     )
 
-  test('uses Route.Bible when selected as the reference link source', () => {
+  test('uses route.bible when selected as the reference link source', () => {
     const suggesting = createVerseSuggesting({
       sourceOfReference: 'routebible',
       bibleVersion: 'kjv',
@@ -48,7 +48,7 @@ describe('VerseSuggesting reference link sources', () => {
     )
   })
 
-  test('preserves same-chapter ranges for Route.Bible links', () => {
+  test('preserves same-chapter ranges for route.bible links', () => {
     const suggesting = createVerseSuggesting(
       {
         sourceOfReference: 'routebible',

--- a/src/verse/VerseSuggesting.referenceLink.test.ts
+++ b/src/verse/VerseSuggesting.referenceLink.test.ts
@@ -1,0 +1,76 @@
+import {
+  BibleReferencePluginSettings,
+  DEFAULT_SETTINGS,
+} from '../data/constants'
+import { VerseSuggesting } from './VerseSuggesting'
+
+jest.mock(
+  'obsidian',
+  () => ({
+    Notice: class Notice {},
+  }),
+  { virtual: true }
+)
+
+class TestVerseSuggesting extends VerseSuggesting {
+  public getReferenceUrl(): string {
+    return this.getUrlForReference()
+  }
+}
+
+describe('VerseSuggesting reference link sources', () => {
+  const createVerseSuggesting = (
+    overrides: Partial<BibleReferencePluginSettings> = {},
+    chapterNumber = 3,
+    verseNumber = 16,
+    verseNumberEnd?: number,
+    chapterNumberEnd?: number,
+    verseNumberEndChapter?: number
+  ) =>
+    new TestVerseSuggesting(
+      { ...DEFAULT_SETTINGS, ...overrides },
+      'John',
+      chapterNumber,
+      verseNumber,
+      verseNumberEnd,
+      chapterNumberEnd,
+      verseNumberEndChapter
+    )
+
+  test('uses Route.Bible when selected as the reference link source', () => {
+    const suggesting = createVerseSuggesting({
+      sourceOfReference: 'routebible',
+      bibleVersion: 'kjv',
+    })
+
+    expect(suggesting.getReferenceUrl()).toBe(
+      'https://route.bible/?q=John+3%3A16&v=KJV&src=obsidian_bible_reference&utm_source=obsidian_bible_reference&utm_medium=obsidian_plugin'
+    )
+  })
+
+  test('preserves same-chapter ranges for Route.Bible links', () => {
+    const suggesting = createVerseSuggesting(
+      {
+        sourceOfReference: 'routebible',
+        bibleVersion: 'esv',
+      },
+      8,
+      28,
+      30
+    )
+
+    expect(suggesting.getReferenceUrl()).toContain('q=John+8%3A28-30')
+    expect(suggesting.getReferenceUrl()).toContain('v=ESV')
+  })
+
+  test('preserves existing biblegateway behavior', () => {
+    const suggesting = createVerseSuggesting({
+      sourceOfReference: 'biblegateway',
+      bibleVersion: 'kjv',
+    })
+
+    expect(suggesting.getReferenceUrl()).toBe(
+      'https://www.biblegateway.com/passage/?search=John+3:16&version=kjv'
+    )
+  })
+})

--- a/src/verse/VerseSuggesting.ts
+++ b/src/verse/VerseSuggesting.ts
@@ -326,7 +326,7 @@ export class VerseSuggesting
             this.bibleVersion
           )
         } catch (error) {
-          console.error('Error generating Route.Bible URL:', error)
+          console.error('Error generating route.bible URL:', error)
           return getBibleGatewayFallback()
         }
       }

--- a/src/verse/VerseSuggesting.ts
+++ b/src/verse/VerseSuggesting.ts
@@ -10,6 +10,7 @@ import { BaseBibleAPIProvider } from '../provider/BaseBibleAPIProvider'
 import { BaseVerseFormatter } from './BaseVerseFormatter'
 import { IVerseSuggesting } from './IVerseSuggesting'
 import { getBLBUrl } from '../utils/referenceBLBAltLinking'
+import { getRouteBibleUrl } from '../utils/referenceRouteBibleLinking'
 import {
   getLogosUrl,
   getLogosTranslation,
@@ -314,6 +315,18 @@ export class VerseSuggesting
           )
         } catch (error) {
           console.error('Error generating Logos URL:', error)
+          return getBibleGatewayFallback()
+        }
+      }
+
+      case 'routebible': {
+        try {
+          return getRouteBibleUrl(
+            getReferenceHead(this.verseReference),
+            this.bibleVersion
+          )
+        } catch (error) {
+          console.error('Error generating Route.Bible URL:', error)
           return getBibleGatewayFallback()
         }
       }


### PR DESCRIPTION
## Summary
Adds route.bible as an optional verse reference hyperlink target alongside the existing `original`, `blb`, `biblegateway`, and `logos` sources.

This keeps the change scoped to the existing reference-link source architecture:
- extend `sourceOfReference` with `routebible`
- add a small route.bible URL helper
- add one `routebible` branch in `VerseSuggesting#getUrlForReference()`
- expose route.bible in the settings dropdown
- add focused tests and a brief README mention

## Behavior
When `Reference Link Source` is set to `route.bible`, generated reference links use route.bible's root resolver URL:

`https://route.bible/?q=<reference>&v=<VERSION>&src=obsidian_bible_reference&utm_source=obsidian_bible_reference&utm_medium=obsidian_plugin&utm_campaign=reference_link_source`

Examples covered in tests:
- `John 3:16`
- `Romans 8:28-30`
- `Hebrews 9:1-10:14`

## Non-goals
- no parser changes
- no suggester changes
- no new parsing dependency
- no route.bible-specific advanced settings
- no change to existing behavior unless the user explicitly selects route.bible

## Validation
- `pnpm build`
- `pnpm lint`
- `pnpm exec jest src/utils/referenceRouteBibleLinking.test.ts src/verse/VerseSuggesting.referenceLink.test.ts --coverage=false`