### PR TITLE
Add Polish UBG/BG via BibleSuperSearch provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 
 You can also get a "verse of the day" by typing `--vod`.
 
+Polish translations are available as well, including **UBG** (Uwspółcześniona Biblia Gdańska) and **BG** (Biblia gdańska).
+
 > Read more about [How to use](https://github.com/tim-hub/obsidian-bible-reference/blob/master/docs/howto.md)
 
 > On iOS devices, there is a known issue about conflict between `Smart Punctuation` and double hyphens `--`.

--- a/docs/bible-api-and-source.md
+++ b/docs/bible-api-and-source.md
@@ -6,6 +6,8 @@ This plugin Bible Verse Query Functionality is currently powered by
   - It is an open source web api that provides a RESTful API for grabbing bible verses and passages.
 - [bolls life bible API](https://bolls.life/api/)
   - It supports more languages and versions, and it has a WEB UI for bible reading as well.
+- [Bible SuperSearch API](https://api.biblesupersearch.com/)
+  - It provides a free API with broad language support, including Polish modules such as UBG and BG.
 
 > The back-end API might be changed in the future to support more languages and versions.
 
@@ -29,6 +31,9 @@ This plugin Bible Verse Query Functionality is currently powered by
   - **LSB**: Legacy Standard Bible (Bolls Life)
   - **DRB**: Douay-Rheims Bible (Bolls Life)
   - and more
+- Bible SuperSearch
+  - **UBG**: Uwspółcześniona Biblia Gdańska, 2017
+  - **BG**: Biblia gdańska, 1881
 
 ### Credits
 
@@ -38,3 +43,4 @@ I must say thanks to all of you, for the help and support. 🙇‍
 | :------------- | :------------------------------------------: | --------------------------------------------------------------------------- |
 | Tim Morgan     |    [@seven1m](https://github.com/seven1m)    | For the open source bible-api project and the maintenance of bible-api.com. |
 | Bolls Life API | [@bpavlisinec](mailto:bpavlisinec@gmail.com) | For the free public bible API.                                              |
+| Bible SuperSearch API | [Bible SuperSearch](https://api.biblesupersearch.com/) | For API access to additional translations including Polish modules. |

--- a/src/data/BibleApiSourceCollection.ts
+++ b/src/data/BibleApiSourceCollection.ts
@@ -8,4 +8,8 @@ export const BibleAPISourceCollection = {
     apiUrl: 'https://bolls.life/get-text', // 'https://bolls.life',
     //  self hosted proxy for bolls life api, https://bible-api-bff.bai.uno/bolls-life
   },
+  bibleSuperSearch: {
+    name: 'Bible SuperSearch',
+    apiUrl: 'https://api.biblesupersearch.com',
+  },
 }

--- a/src/data/BibleVersionCollection.ts
+++ b/src/data/BibleVersionCollection.ts
@@ -457,14 +457,14 @@ export const BibleVersionCollectionPolish = [
     versionName: 'Biblia gdańska, 1881',
     language: 'Polish',
     code: 'pl',
-    apiSource: BibleAPISourceCollection.bollsLife,
+    apiSource: BibleAPISourceCollection.bibleSuperSearch,
   },
   {
-    key: 'bw',
-    versionName: 'Biblia warszawska, 1975',
+    key: 'ubg',
+    versionName: 'Uwspółcześniona Biblia Gdańska, 2017',
     language: 'Polish',
     code: 'pl',
-    apiSource: BibleAPISourceCollection.bollsLife,
+    apiSource: BibleAPISourceCollection.bibleSuperSearch,
   },
 ]
 

--- a/src/provider/BibleSuperSearchProvider.test.ts
+++ b/src/provider/BibleSuperSearchProvider.test.ts
@@ -1,0 +1,72 @@
+import { BibleSuperSearchProvider } from './BibleSuperSearchProvider'
+import { BibleAPISourceCollection } from '../data/BibleApiSourceCollection'
+
+jest.mock(
+  'obsidian',
+  () => ({
+    Notice: jest.fn(),
+  }),
+  { virtual: true }
+)
+
+describe('BibleSuperSearchProvider', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('builds query URL with mapped bg module', () => {
+    const provider = new BibleSuperSearchProvider({
+      key: 'bg',
+      versionName: 'Biblia gdańska, 1881',
+      language: 'Polish',
+      code: 'pl',
+      apiSource: BibleAPISourceCollection.bibleSuperSearch,
+    })
+
+    const url = provider.buildRequestURL('John', 3, [16], 'bg')
+
+    expect(url).toContain('/api?')
+    expect(url).toContain('bible=polbg')
+    expect(url).toContain('reference=John+3%3A16')
+    expect(url).toContain('data_format=minimal')
+  })
+
+  it('queries and normalizes verse response for ubg', async () => {
+    const provider = new BibleSuperSearchProvider({
+      key: 'ubg',
+      versionName: 'Uwspółcześniona Biblia Gdańska, 2017',
+      language: 'Polish',
+      code: 'pl',
+      apiSource: BibleAPISourceCollection.bibleSuperSearch,
+    })
+
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      json: async () => ({
+        errors: [],
+        error_level: 0,
+        results: {
+          pol_ubg: [
+            {
+              id: 26137,
+              book: 43,
+              chapter: 3,
+              verse: 16,
+              text: 'Tak bowiem Bóg umiłował świat...',
+            },
+          ],
+        },
+      }),
+    } as Response)
+
+    const verses = await provider.query('John', 3, [16], 'ubg')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(verses).toHaveLength(1)
+    expect(verses[0]).toMatchObject({
+      chapter: 3,
+      verse: 16,
+      book_id: '43',
+      book_name: 'John',
+    })
+  })
+})

--- a/src/provider/BibleSuperSearchProvider.ts
+++ b/src/provider/BibleSuperSearchProvider.ts
@@ -1,0 +1,79 @@
+import { IVerse } from '../interfaces/IVerse'
+import { IBibleVersion } from '../interfaces/IBibleVersion'
+import { BaseBibleAPIProvider } from './BaseBibleAPIProvider'
+
+type BibleSuperSearchVerse = {
+  id: number | string
+  book: number | string
+  chapter: number | string
+  verse: number | string
+  text: string
+}
+
+type BibleSuperSearchResponse = {
+  errors?: string[]
+  error_level?: number
+  results?: Record<string, BibleSuperSearchVerse[]>
+}
+
+const BIBLE_SUPER_SEARCH_MODULES: Record<string, string> = {
+  bg: 'polbg',
+  ubg: 'pol_ubg',
+}
+
+export class BibleSuperSearchProvider extends BaseBibleAPIProvider {
+  public constructor(bibleVersion: IBibleVersion) {
+    super(bibleVersion)
+  }
+
+  private getModuleKey(versionName?: string): string {
+    const inputKey = versionName || this.BibleVersionKey
+    const normalized = inputKey.toLowerCase()
+    return BIBLE_SUPER_SEARCH_MODULES[normalized] || normalized
+  }
+
+  public buildRequestURL(
+    bookName: string,
+    chapter: number,
+    verses: number[] = [],
+    versionName?: string
+  ): string {
+    const moduleKey = this.getModuleKey(versionName)
+    const verseQuery = this.convertVersesToQueryString(verses)
+    const reference = `${bookName} ${chapter}:${verseQuery}`
+    const searchParams = new URLSearchParams({
+      bible: moduleKey,
+      reference,
+      data_format: 'minimal',
+    })
+
+    this._currentQueryUrl = `${this._apiUrl}/api?${searchParams.toString()}`
+    return this._currentQueryUrl
+  }
+
+  protected formatBibleVerses(
+    data:
+      | {
+          reference: string
+          verses: IVerse[]
+        }
+      | Array<object>,
+    bookName: string,
+    chapter: number,
+    verses: number[],
+    versionName: string
+  ): IVerse[] {
+    this._bibleReferenceHead = `${bookName} ${chapter}:${this.convertVersesToQueryString(verses)}`
+    const moduleKey = this.getModuleKey(versionName)
+    const response = data as BibleSuperSearchResponse
+    const rows = response?.results?.[moduleKey] || []
+
+    return rows.map((row) => ({
+      text: row.text,
+      chapter: Number(row.chapter) || chapter,
+      book_id: String(row.book),
+      book_name: bookName,
+      verse: Number(row.verse),
+    }))
+  }
+}

--- a/src/provider/ProviderFactory.ts
+++ b/src/provider/ProviderFactory.ts
@@ -3,6 +3,7 @@ import { BibleAPIDotComProvider } from './BibleAPIDotComProvider'
 import { BaseBibleAPIProvider } from './BaseBibleAPIProvider'
 import { BibleAPISourceCollection } from '../data/BibleApiSourceCollection'
 import { BollyLifeProvider } from './BollyLifeProvider'
+import { BibleSuperSearchProvider } from './BibleSuperSearchProvider'
 
 /**
  * A factory for Bible API providers.
@@ -47,6 +48,9 @@ export class ProviderFactory {
       }
       case BibleAPISourceCollection.bollsLife: {
         return new BollyLifeProvider(bibleVersion)
+      }
+      case BibleAPISourceCollection.bibleSuperSearch: {
+        return new BibleSuperSearchProvider(bibleVersion)
       }
       default: {
         return new BibleAPIDotComProvider(bibleVersion)


### PR DESCRIPTION
## Summary
- add a dedicated `BibleSuperSearchProvider` and route it via `ProviderFactory`
- register a new `bibleSuperSearch` API source and switch Polish translations to `UBG` and `BG`
- add provider tests plus documentation updates in README and API/source docs

## Test plan
- [x] `npm run test -- --runInBand`
- [x] `npm run build`
- [x] verify no lints in modified files

Made with [Cursor](https://cursor.com)