### PR TITLE
Fix multi-chapter verse tagging

### DIFF
--- a/src/verse/BaseVerseFormatter.test.ts
+++ b/src/verse/BaseVerseFormatter.test.ts
@@ -371,4 +371,97 @@ describe('BaseVerseFormatter', () => {
       true
     )
   })
+  it('should add multiple chapter tags for cross-chapter reference (e.g. James 1:1-2:1)', () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      chapterTagging: true,
+      chapterTaggingFormat: '{{book}}{{chapter}}',
+    }
+    const verseReference: VerseReference = {
+      bookName: 'James',
+      chapterNumber: 1,
+      verseNumber: 1,
+      chapterNumberEnd: 2,
+      verseNumberEndChapter: 1,
+      ranges: [
+        {
+          chapterNumber: 1,
+          verseNumber: 1,
+          chapterNumberEnd: 2,
+          verseNumberEndChapter: 1,
+        },
+      ],
+    }
+    const verses = [
+      {
+        book_id: 'James',
+        book_name: 'James',
+        chapter: 1,
+        verse: 1,
+        text: 'v1',
+      },
+      {
+        book_id: 'James',
+        book_name: 'James',
+        chapter: 2,
+        verse: 1,
+        text: 'v2',
+      },
+    ]
+    const formatter = new MockFormatter(settings, verseReference, verses)
+    expect(formatter.allFormattedContent).toContain('#James1')
+    expect(formatter.allFormattedContent).toContain('#James2')
+  })
+  it('should add multiple chapter tags including book tag for cross-chapter reference', () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      bookTagging: true,
+      bookTaggingFormat: '{{book}}',
+      chapterTagging: true,
+      chapterTaggingFormat: '{{book}}{{chapter}}',
+    }
+    const verseReference: VerseReference = {
+      bookName: 'Hebrews',
+      chapterNumber: 9,
+      verseNumber: 1,
+      chapterNumberEnd: 11,
+      verseNumberEndChapter: 3,
+      ranges: [
+        {
+          chapterNumber: 9,
+          verseNumber: 1,
+          chapterNumberEnd: 11,
+          verseNumberEndChapter: 3,
+        },
+      ],
+    }
+    const verses = [
+      {
+        book_id: 'Hebrews',
+        book_name: 'Hebrews',
+        chapter: 9,
+        verse: 1,
+        text: 'a',
+      },
+      {
+        book_id: 'Hebrews',
+        book_name: 'Hebrews',
+        chapter: 10,
+        verse: 1,
+        text: 'b',
+      },
+      {
+        book_id: 'Hebrews',
+        book_name: 'Hebrews',
+        chapter: 11,
+        verse: 3,
+        text: 'c',
+      },
+    ]
+    const formatter = new MockFormatter(settings, verseReference, verses)
+    expect(formatter.allFormattedContent).toContain('#Hebrews')
+    expect(formatter.allFormattedContent).toContain('#Hebrews9')
+    expect(formatter.allFormattedContent).toContain('#Hebrews10')
+    expect(formatter.allFormattedContent).toContain('#Hebrews11')
+  })
 })

--- a/src/verse/BaseVerseFormatter.ts
+++ b/src/verse/BaseVerseFormatter.ts
@@ -185,14 +185,19 @@ export abstract class BaseVerseFormatter {
             this.settings.bookTaggingFormat
           )
         : ''
-      bottom += this.settings?.chapterTagging
-        ? ' ' +
-          getChapterTag(
-            this.verseReference.bookName,
-            this.verseReference.chapterNumber,
-            this.settings.chapterTaggingFormat
-          )
-        : ''
+      if (this.settings?.chapterTagging) {
+        const startChapter = this.verseReference.chapterNumber
+        const endChapter = this.verseReference.chapterNumberEnd ?? startChapter
+        for (let ch = startChapter; ch <= endChapter; ch++) {
+          bottom +=
+            ' ' +
+            getChapterTag(
+              this.verseReference.bookName,
+              ch,
+              this.settings.chapterTaggingFormat
+            )
+        }
+      }
       bottom += ' %%'
     }
     return bottom


### PR DESCRIPTION
The bug was that cross-chapter references like `James 1:1-2:1` only generated `#James1`, missing subsequent chapters.

The fix was to loop from `chapterNumber` to `chapterNumberEnd` when generating chapter tags, producing `#James1 #James2` as expected.

# Before:
<img width="561" height="431" alt="image" src="https://github.com/user-attachments/assets/50773194-8fd4-4445-8d60-0a4df91978cd" />


# Now:
<img width="562" height="437" alt="image" src="https://github.com/user-attachments/assets/1b6d1650-b7fb-4ab9-b22a-c29e55420b13" />
