### PR TITLE
feat: map php to Philippians and override isa to map to Isaiah

### DIFF
--- a/src/utils/bookNameReference.test.ts
+++ b/src/utils/bookNameReference.test.ts
@@ -32,6 +32,14 @@ describe('test bookNameReference', () => {
       )
     }
   })
+
+  it('should map php to Philippians (50)', () => {
+    expect(getBookIdFromBookName('php')).toBe(50)
+  })
+
+  it('should override isa to map to Isaiah (23)', () => {
+    expect(getBookIdFromBookName('isa')).toBe(23)
+  })
 })
 
 describe('test getFullBookName', () => {
@@ -52,5 +60,13 @@ describe('test getFullBookName', () => {
     // When language code is invalid, it should fallback to English
     const result = getFullBookName('Genesis', 'invalidCode')
     expect(result).toBe('Genesis')
+  })
+
+  it('should return Philippians for php in English', () => {
+    expect(getFullBookName('php', 'en')).toBe('Philippians')
+  })
+
+  it('should return Isaiah for isa in English', () => {
+    expect(getFullBookName('isa', 'en')).toBe('Isaiah')
   })
 })

--- a/src/utils/bookNameReference.ts
+++ b/src/utils/bookNameReference.ts
@@ -4,6 +4,13 @@ export const getBookIdFromBookName = (
   bookName: string,
   languageCode: string = 'en'
 ): number => {
+  const normalized = bookName.trim().toLowerCase()
+  if (normalized === 'php') {
+    return 50
+  }
+  if (normalized === 'isa') {
+    return 23
+  }
   try {
     console.debug('get book id first time', bookName, languageCode)
     return Reference.bookIdFromTranslationAndName(languageCode, bookName)


### PR DESCRIPTION
I wasn't sure if I should just update the toolkit. I saw that the Repository: https://github.com/tim-hub/bible-reference-toolkit hasn't been updated in a few years. 

Anyways, this is to fix a pet peeve of mine. php is a common abbr. for philippians.

I've seen others complain about how isa maps to 1 Samuel instead of Isaiah (isa is a common abbr. for Isaiah)

Feel free to reject this if you disagree or think that I should instead update the toolkit package instead.