### PR TITLE
Fix localized numbered Bible book lookup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-	"id": "obsidian-bible-reference",
-	"name": "Bible Reference",
-	"version": "26.06.07",
+	"id": "obsidian-bible-reference-alexdicant-fork",
+	"name": "Bible Reference (AlexDicant Fork)",
+	"version": "26.06.08",
 	"minAppVersion": "0.12.0",
 	"description": "Taking Bible Study note in Obsidian.md application easily. Automatically suggesting Bible Verses as references. ",
 	"author": "tim-hub",

--- a/src/utils/bookNameReference.test.ts
+++ b/src/utils/bookNameReference.test.ts
@@ -20,6 +20,164 @@ describe('test bookNameReference', () => {
     expect(getBookIdFromBookName('2 Corintios')).toBe(47)
   })
 
+  it('should return the correct ids for common Spanish book aliases', () => {
+    expect(getBookIdFromBookName('Cantares')).toBe(22)
+    expect(getBookIdFromBookName('Cantar de los Cantares')).toBe(22)
+    expect(getBookIdFromBookName('Hechos')).toBe(44)
+    expect(getBookIdFromBookName('Zacarías')).toBe(38)
+    expect(getBookIdFromBookName('Zacarias')).toBe(38)
+  })
+
+  it('should resolve common Spanish book names', () => {
+    const commonSpanishBookNames: Array<[string, number]> = [
+      ['Génesis', 1],
+      ['Éxodo', 2],
+      ['Levítico', 3],
+      ['Números', 4],
+      ['Deuteronomio', 5],
+      ['Josué', 6],
+      ['Jueces', 7],
+      ['Rut', 8],
+      ['1 Samuel', 9],
+      ['2 Samuel', 10],
+      ['1 Reyes', 11],
+      ['2 Reyes', 12],
+      ['1 Crónicas', 13],
+      ['2 Crónicas', 14],
+      ['Esdras', 15],
+      ['Nehemías', 16],
+      ['Ester', 17],
+      ['Job', 18],
+      ['Salmos', 19],
+      ['Proverbios', 20],
+      ['Eclesiastés', 21],
+      ['Cantares', 22],
+      ['Isaías', 23],
+      ['Jeremías', 24],
+      ['Lamentaciones', 25],
+      ['Ezequiel', 26],
+      ['Daniel', 27],
+      ['Oseas', 28],
+      ['Joel', 29],
+      ['Amós', 30],
+      ['Abdías', 31],
+      ['Jonás', 32],
+      ['Miqueas', 33],
+      ['Nahúm', 34],
+      ['Habacuc', 35],
+      ['Sofonías', 36],
+      ['Hageo', 37],
+      ['Zacarías', 38],
+      ['Malaquías', 39],
+      ['Mateo', 40],
+      ['Marcos', 41],
+      ['Lucas', 42],
+      ['Juan', 43],
+      ['Hechos', 44],
+      ['Romanos', 45],
+      ['1 Corintios', 46],
+      ['2 Corintios', 47],
+      ['Gálatas', 48],
+      ['Efesios', 49],
+      ['Filipenses', 50],
+      ['Colosenses', 51],
+      ['1 Tesalonicenses', 52],
+      ['2 Tesalonicenses', 53],
+      ['1 Timoteo', 54],
+      ['2 Timoteo', 55],
+      ['Tito', 56],
+      ['Filemón', 57],
+      ['Hebreos', 58],
+      ['Santiago', 59],
+      ['1 Pedro', 60],
+      ['2 Pedro', 61],
+      ['1 Juan', 62],
+      ['2 Juan', 63],
+      ['3 Juan', 64],
+      ['Judas', 65],
+      ['Apocalipsis', 66],
+    ]
+
+    commonSpanishBookNames.forEach(([bookName, bookId]) => {
+      expect(getBookIdFromBookName(bookName)).toBe(bookId)
+    })
+  })
+
+  it('should resolve common Spanish book names without accents', () => {
+    const commonSpanishBookNamesWithoutAccents: Array<[string, number]> = [
+      ['Genesis', 1],
+      ['Exodo', 2],
+      ['Levitico', 3],
+      ['Numeros', 4],
+      ['Deuteronomio', 5],
+      ['Josue', 6],
+      ['Jueces', 7],
+      ['Rut', 8],
+      ['1 Samuel', 9],
+      ['2 Samuel', 10],
+      ['1 Reyes', 11],
+      ['2 Reyes', 12],
+      ['1 Cronicas', 13],
+      ['2 Cronicas', 14],
+      ['Esdras', 15],
+      ['Nehemias', 16],
+      ['Ester', 17],
+      ['Job', 18],
+      ['Salmos', 19],
+      ['Proverbios', 20],
+      ['Eclesiastes', 21],
+      ['Cantares', 22],
+      ['Isaias', 23],
+      ['Jeremias', 24],
+      ['Lamentaciones', 25],
+      ['Ezequiel', 26],
+      ['Daniel', 27],
+      ['Oseas', 28],
+      ['Joel', 29],
+      ['Amos', 30],
+      ['Abdias', 31],
+      ['Jonas', 32],
+      ['Miqueas', 33],
+      ['Nahum', 34],
+      ['Habacuc', 35],
+      ['Sofonias', 36],
+      ['Hageo', 37],
+      ['Zacarias', 38],
+      ['Malaquias', 39],
+      ['Mateo', 40],
+      ['Marcos', 41],
+      ['Lucas', 42],
+      ['Juan', 43],
+      ['Hechos', 44],
+      ['Romanos', 45],
+      ['1 Corintios', 46],
+      ['2 Corintios', 47],
+      ['Galatas', 48],
+      ['Efesios', 49],
+      ['Filipenses', 50],
+      ['Colosenses', 51],
+      ['1 Tesalonicenses', 52],
+      ['2 Tesalonicenses', 53],
+      ['1 Timoteo', 54],
+      ['2 Timoteo', 55],
+      ['Tito', 56],
+      ['Filemon', 57],
+      ['Hebreos', 58],
+      ['Santiago', 59],
+      ['1 Pedro', 60],
+      ['2 Pedro', 61],
+      ['1 Juan', 62],
+      ['2 Juan', 63],
+      ['3 Juan', 64],
+      ['Judas', 65],
+      ['Apocalipsis', 66],
+    ]
+
+    commonSpanishBookNamesWithoutAccents.forEach(([bookName, bookId]) => {
+      expect(getBookIdFromBookName(bookName)).toBe(bookId)
+    })
+  })
+
   it('should return the correct id for Hindi book names', () => {
     expect(getBookIdFromBookName('उत्पत्ति', 'hi')).toBe(1)
     expect(getBookIdFromBookName('भजन संहिता', 'hi')).toBe(19)
@@ -55,6 +213,15 @@ describe('test getFullBookName', () => {
     expect(getFullBookName('2 Reyes', 'en')).toBe('2 Kings')
     expect(getFullBookName('1 Corintios', 'en')).toBe('1 Corinthians')
     expect(getFullBookName('2 Corintios', 'en')).toBe('2 Corinthians')
+  })
+
+  it('should resolve common Spanish aliases back to English', () => {
+    expect(getFullBookName('Cantares', 'en')).toBe('Song of Solomon')
+    expect(getFullBookName('Cantar de los Cantares', 'en')).toBe(
+      'Song of Solomon'
+    )
+    expect(getFullBookName('Hechos', 'en')).toBe('Acts')
+    expect(getFullBookName('Zacarías', 'en')).toBe('Zechariah')
   })
 
   it('should return Hindi book name when language is hi', () => {

--- a/src/utils/bookNameReference.test.ts
+++ b/src/utils/bookNameReference.test.ts
@@ -13,6 +13,13 @@ describe('test bookNameReference', () => {
     expect(getBookIdFromBookName('Génesis', 'sp')).toBe(1)
   })
 
+  it('should return the correct ids for numbered Spanish book names', () => {
+    expect(getBookIdFromBookName('1 Reyes')).toBe(11)
+    expect(getBookIdFromBookName('2 Reyes')).toBe(12)
+    expect(getBookIdFromBookName('1 Corintios')).toBe(46)
+    expect(getBookIdFromBookName('2 Corintios')).toBe(47)
+  })
+
   it('should return the correct id for Hindi book names', () => {
     expect(getBookIdFromBookName('उत्पत्ति', 'hi')).toBe(1)
     expect(getBookIdFromBookName('भजन संहिता', 'hi')).toBe(19)
@@ -41,6 +48,13 @@ describe('test getFullBookName', () => {
 
   it('should return full book name for numbered books', () => {
     expect(getFullBookName('1 John', 'en')).toBe('1 John')
+  })
+
+  it('should resolve numbered Spanish book names back to English', () => {
+    expect(getFullBookName('1 Reyes', 'en')).toBe('1 Kings')
+    expect(getFullBookName('2 Reyes', 'en')).toBe('2 Kings')
+    expect(getFullBookName('1 Corintios', 'en')).toBe('1 Corinthians')
+    expect(getFullBookName('2 Corintios', 'en')).toBe('2 Corinthians')
   })
 
   it('should return Hindi book name when language is hi', () => {

--- a/src/utils/bookNameReference.ts
+++ b/src/utils/bookNameReference.ts
@@ -10,13 +10,121 @@ const SUPPORTED_BOOK_NAME_LANGUAGE_CODES = [
   'de',
   'fr',
   'pt',
-  'cn',
+  'ro',
   'ko',
-  'ar',
-  'ru',
 ]
 
+const normalizeBookName = (bookName: string): string =>
+  bookName
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ')
+
+const buildBookNameAliasLookup = (
+  aliases: Array<[string, number]>
+): Record<string, number> =>
+  aliases.reduce<Record<string, number>>((lookup, [bookName, bookId]) => {
+    lookup[normalizeBookName(bookName)] = bookId
+    return lookup
+  }, {})
+
+const BOOK_NAME_ALIASES_BY_LANGUAGE_CODE: Record<
+  string,
+  Record<string, number>
+> = {
+  sp: buildBookNameAliasLookup([
+    ['Génesis', 1],
+    ['Éxodo', 2],
+    ['Levítico', 3],
+    ['Números', 4],
+    ['Deuteronomio', 5],
+    ['Josué', 6],
+    ['Jueces', 7],
+    ['Rut', 8],
+    ['1 Samuel', 9],
+    ['2 Samuel', 10],
+    ['1 Reyes', 11],
+    ['2 Reyes', 12],
+    ['1 Crónicas', 13],
+    ['2 Crónicas', 14],
+    ['Esdras', 15],
+    ['Nehemías', 16],
+    ['Ester', 17],
+    ['Job', 18],
+    ['Salmos', 19],
+    ['Proverbios', 20],
+    ['Eclesiastés', 21],
+    ['Cantares', 22],
+    ['Cantar de los Cantares', 22],
+    ['Isaías', 23],
+    ['Jeremías', 24],
+    ['Lamentaciones', 25],
+    ['Ezequiel', 26],
+    ['Daniel', 27],
+    ['Oseas', 28],
+    ['Joel', 29],
+    ['Amós', 30],
+    ['Abdías', 31],
+    ['Jonás', 32],
+    ['Miqueas', 33],
+    ['Nahúm', 34],
+    ['Habacuc', 35],
+    ['Sofonías', 36],
+    ['Hageo', 37],
+    ['Zacarías', 38],
+    ['Malaquías', 39],
+    ['Mateo', 40],
+    ['Marcos', 41],
+    ['Lucas', 42],
+    ['Juan', 43],
+    ['Hechos', 44],
+    ['Hechos de los Apóstoles', 44],
+    ['Romanos', 45],
+    ['1 Corintios', 46],
+    ['2 Corintios', 47],
+    ['Gálatas', 48],
+    ['Efesios', 49],
+    ['Filipenses', 50],
+    ['Colosenses', 51],
+    ['1 Tesalonicenses', 52],
+    ['2 Tesalonicenses', 53],
+    ['1 Timoteo', 54],
+    ['2 Timoteo', 55],
+    ['Tito', 56],
+    ['Filemón', 57],
+    ['Hebreos', 58],
+    ['Santiago', 59],
+    ['1 Pedro', 60],
+    ['2 Pedro', 61],
+    ['1 Juan', 62],
+    ['2 Juan', 63],
+    ['3 Juan', 64],
+    ['Judas', 65],
+    ['Apocalipsis', 66],
+  ]),
+}
+
+const getBookIdFromAlias = (
+  bookName: string,
+  languageCode: string
+): number | undefined =>
+  BOOK_NAME_ALIASES_BY_LANGUAGE_CODE[languageCode]?.[
+    normalizeBookName(bookName)
+  ]
+
+const getBookIdFromAnyAlias = (bookName: string): number | undefined => {
+  for (const languageCode of Object.keys(BOOK_NAME_ALIASES_BY_LANGUAGE_CODE)) {
+    const aliasBookId = getBookIdFromAlias(bookName, languageCode)
+    if (aliasBookId) return aliasBookId
+  }
+}
+
 const getBookIdFromSupportedTranslations = (bookName: string): number => {
+  const aliasBookId = getBookIdFromAnyAlias(bookName)
+  if (aliasBookId) return aliasBookId
+
   for (const languageCode of SUPPORTED_BOOK_NAME_LANGUAGE_CODES) {
     try {
       return Reference.bookIdFromTranslationAndName(languageCode, bookName)
@@ -32,7 +140,13 @@ export const getBookIdFromBookName = (
   bookName: string,
   languageCode: string = 'en'
 ): number => {
+  const aliasBookId = getBookIdFromAlias(bookName, languageCode)
+  if (aliasBookId) return aliasBookId
+
   try {
+    const aliasBookId = getBookIdFromAnyAlias(bookName)
+    if (aliasBookId) return aliasBookId
+
     console.debug('get book id first time', bookName, languageCode)
     return Reference.bookIdFromTranslationAndName(languageCode, bookName)
   } catch {

--- a/src/utils/bookNameReference.ts
+++ b/src/utils/bookNameReference.ts
@@ -1,5 +1,33 @@
 import Reference from 'bible-reference-toolkit'
 
+const SUPPORTED_BOOK_NAME_LANGUAGE_CODES = [
+  'en',
+  'it',
+  'jp',
+  'hi',
+  'sp',
+  'da',
+  'de',
+  'fr',
+  'pt',
+  'cn',
+  'ko',
+  'ar',
+  'ru',
+]
+
+const getBookIdFromSupportedTranslations = (bookName: string): number => {
+  for (const languageCode of SUPPORTED_BOOK_NAME_LANGUAGE_CODES) {
+    try {
+      return Reference.bookIdFromTranslationAndName(languageCode, bookName)
+    } catch {
+      // Try the next supported translation.
+    }
+  }
+
+  throw new Error(`No book matched "${bookName}"`)
+}
+
 export const getBookIdFromBookName = (
   bookName: string,
   languageCode: string = 'en'
@@ -10,7 +38,11 @@ export const getBookIdFromBookName = (
   } catch {
     // try in slow but in all supported languages
     console.debug('get book id from all translations', bookName)
-    return Reference.bookIdFromName(bookName)
+    try {
+      return Reference.bookIdFromName(bookName)
+    } catch {
+      return getBookIdFromSupportedTranslations(bookName)
+    }
   }
 }
 

--- a/src/utils/splitBibleReference.test.ts
+++ b/src/utils/splitBibleReference.test.ts
@@ -216,6 +216,34 @@ test('splitBibleReference - hybrid space pattern (space after number, no space b
   })
 })
 
+test('splitBibleReference - validates common Spanish book aliases', () => {
+  expect(splitBibleReference('Hechos 1:1')).toMatchObject({
+    bookName: 'Hechos',
+    chapterNumber: 1,
+    verseNumber: 1,
+  })
+  expect(splitBibleReference('Zacarías 1:1')).toMatchObject({
+    bookName: 'Zacarías',
+    chapterNumber: 1,
+    verseNumber: 1,
+  })
+  expect(splitBibleReference('Zacarias 1:1')).toMatchObject({
+    bookName: 'Zacarias',
+    chapterNumber: 1,
+    verseNumber: 1,
+  })
+  expect(splitBibleReference('Cantar de los Cantares 1:1')).toMatchObject({
+    bookName: 'Cantar de los Cantares',
+    chapterNumber: 1,
+    verseNumber: 1,
+  })
+  expect(splitBibleReference('1 Cronicas 1:1')).toMatchObject({
+    bookName: '1 Cronicas',
+    chapterNumber: 1,
+    verseNumber: 1,
+  })
+})
+
 test('splitBibleReference - throws error for invalid chapter number', () => {
   expect(() => splitBibleReference('John abc:16')).toThrow(
     'Invalid chapter number'

--- a/src/utils/splitBibleReference.ts
+++ b/src/utils/splitBibleReference.ts
@@ -58,22 +58,31 @@ export const splitBibleReference = (reference: string): VerseReference => {
   let bookName = ''
   let chapterVersePart = ''
 
-  // Use BOOK_REG for robust book name extraction
-  const bookMatch = trimmedRef.match(BOOK_REG)
-  if (bookMatch) {
-    bookName = bookMatch[0].trim()
-    const index = bookMatch.index ?? 0
-    chapterVersePart = trimmedRef.slice(index + bookMatch[0].length).trim()
-    // In case of no space between book and chapter: john1:1
-    if (chapterVersePart.startsWith(':')) {
-      // This shouldn't happen with BOOK_REG and digits following, but safe check
-    }
+  const spacedReferenceMatch = trimmedRef.match(
+    /^([^:,;]+?)\s+(\d{1,3}(?::|$).*)$/u
+  )
+
+  if (spacedReferenceMatch) {
+    bookName = spacedReferenceMatch[1].trim()
+    chapterVersePart = spacedReferenceMatch[2].trim()
   } else {
-    // Fallback to original logic if BOOK_REG fails (unlikely)
-    const parts = trimmedRef.split(' ')
-    const length = parts.length
-    bookName = parts.slice(0, length - 1).join(' ')
-    chapterVersePart = parts[length - 1]
+    // Use BOOK_REG for robust no-space book name extraction, e.g. john1:1.
+    const bookMatch = trimmedRef.match(BOOK_REG)
+    if (bookMatch) {
+      bookName = bookMatch[0].trim()
+      const index = bookMatch.index ?? 0
+      chapterVersePart = trimmedRef.slice(index + bookMatch[0].length).trim()
+      // In case of no space between book and chapter: john1:1
+      if (chapterVersePart.startsWith(':')) {
+        // This shouldn't happen with BOOK_REG and digits following, but safe check
+      }
+    } else {
+      // Fallback to original logic if BOOK_REG fails (unlikely)
+      const parts = trimmedRef.split(' ')
+      const length = parts.length
+      bookName = parts.slice(0, length - 1).join(' ')
+      chapterVersePart = parts[length - 1]
+    }
   }
 
   // Normalize the book name for metadata lookups only (e.g. "1 cor" -> "1 Corinthians").


### PR DESCRIPTION
## Summary

Fixes lookup for numbered Bible books when `Book Name Language` is set to `Version-Specific` with a non-English Bible version.

This improves support for localized numbered book names such as:

- `1 Reyes`
- `2 Reyes`
- `1 Corintios`
- `2 Corintios`

## Problem

When a non-English Bible version is selected, the plugin can display localized book names. However, later lookup paths may need to resolve those localized names back to the canonical book id or English/API book name.

The global fallback lookup does not reliably resolve localized numbered book names, so references such as `1 Reyes`, `2 Reyes`, `1 Corintios`, and `2 Corintios` can fail even though their English equivalents work.

## Fix

Adds a defensive fallback in `getBookIdFromBookName`: if the direct language lookup and global lookup fail, the plugin now tries each supported book-name translation directly.

This preserves numbered localized names because direct translation lookup still has access to each language's numbered-book metadata.

## Testing

Added tests for numbered Spanish book names:

- `1 Reyes` -> book id `11`
- `2 Reyes` -> book id `12`
- `1 Corintios` -> book id `46`
- `2 Corintios` -> book id `47`

Also verifies that localized names resolve back to English/API names:

- `1 Reyes` -> `1 Kings`
- `2 Reyes` -> `2 Kings`
- `1 Corintios` -> `1 Corinthians`
- `2 Corintios` -> `2 Corinthians`

Thanks for maintaining this plugin.