### PR TITLE
fix: localized numbered books + repoint Clementine Vulgate

### DIFF
--- a/packages/bible-reference-toolkit/src/lib/books.ts
+++ b/packages/bible-reference-toolkit/src/lib/books.ts
@@ -35,12 +35,16 @@ const getAllBibleBooksInAllSupportedLanguages = (): BookWithAbbreviations[] => {
   for (let i = 0; i < 66; i++) {
     // @ts-ignore
     const enTranslation = LanguageToBookWithAbbreviationsDict?.get('en')[i];
-    const { fullName, verses, name } = enTranslation;
+    const { fullName, verses, name, startNumber } = enTranslation;
 
     const book: BookWithAbbreviations = {
       name, // this is the name of the book in English
       fullName, // this is the full name of the book in English
       verses,
+      // Preserve startNumber so the cross-language ordinal fallback can match
+      // localized numbered books (e.g. "1 Könige", "2 Corintios"); without it,
+      // numbered books only resolved through the per-translation lookup.
+      startNumber,
       abbreviations: [] as string[], // this will be the list of abbreviations and names for the book in all languages
     };
 

--- a/packages/bible-reference-toolkit/src/test/reference.ext.test.ts
+++ b/packages/bible-reference-toolkit/src/test/reference.ext.test.ts
@@ -57,3 +57,20 @@ describe('Reference Original Test in Other Languages', () => {
     expect(Reference.bookNameFromTranslationAndId('sp', 62)).toBe('1 Juan');
   });
 });
+
+// Regression: localized numbered books must resolve through the cross-language
+// bookIdFromName fallback, not only per-translation lookup. The provider maps a
+// localized name to English via this path, so failure here dropped the verse
+// text (issues #355, #342).
+describe('Cross-language numbered book resolution (bookIdFromName)', () => {
+  test.each([
+    ['1 Könige', 11],
+    ['1Könige', 11],
+    ['1 Reyes', 11],
+    ['2 Corintios', 47],
+    ['1 Corinthians', 46],
+    ['1 Kings', 11],
+  ])('resolves %s', (name, expectedId) => {
+    expect(Reference.bookIdFromName(name)).toBe(expectedId);
+  });
+});

--- a/packages/obsidian-bible-reference/src/data/BibleVersionCollection.ts
+++ b/packages/obsidian-bible-reference/src/data/BibleVersionCollection.ts
@@ -220,11 +220,13 @@ export const BibleVersionCollectionEnglish = [
 
 export const BibleVersionCollectionLatin = [
   {
-    key: 'clementine',
+    // bible-api.com dropped this translation (returns 404), so it resolves via
+    // bolls.life's 'VULG' (Biblia Sacra juxta Vulgatam Clementinam) instead.
+    key: 'vulg',
     versionName: 'Clementine Latin Vulgate',
     language: 'Latin',
     code: 'la',
-    apiSource: BibleAPISourceCollection.bibleApi,
+    apiSource: BibleAPISourceCollection.bollsLife,
   },
 ]
 

--- a/packages/obsidian-bible-reference/src/provider/BibleAPIDotComProvider.ts
+++ b/packages/obsidian-bible-reference/src/provider/BibleAPIDotComProvider.ts
@@ -7,7 +7,7 @@ import { BaseBibleAPIProvider } from './BaseBibleAPIProvider'
  * const translationKeysFromBibleAPIDotCom: string[] = allBibleVersionsWithLanguageNameAlphabetically.filter(
  *     (version) => version.apiSource.name === 'Bible API'
  *   ).map((version) => version.key)
- * ['cherokee', 'bbe', 'kjv', 'oeb-us', 'web', 'oeb-cw', 'webbe', 'clementine', 'almeida', 'rccv']
+ * ['cherokee', 'bbe', 'kjv', 'oeb-us', 'web', 'oeb-cw', 'webbe', 'almeida', 'rccv']
  */
 
 // const bibleGatewaySupportedTranslations = [


### PR DESCRIPTION
## Summary
Fixes three related bug reports.

### #355 + #342 — localized numbered books return no verse text
Numbered books under non-English / version-specific naming (`1 Könige`, `2 Corintios`, `1 Reyes`, …) rendered a link but no verse text.

**Root cause:** `AllBibleBooksInAllSupportedLanguages` dropped `startNumber`. The cross-language ordinal fallback (`bookIdFromName`) skips any book without `startNumber`, and that is exactly the path the provider uses to map a localized book name to English before fetching. So the fetch threw and the verse text was silently dropped (link still rendered). English worked only because the per-translation lookup runs first.

**Fix:** preserve `startNumber` in the merged catalog. Added a regression test covering `1 Könige`, `1Könige`, `1 Reyes`, `2 Corintios`, `1 Corinthians`, `1 Kings`.

### #357 — Clementine Latin Vulgate API error
`bible-api.com` dropped the `clementine` translation — it now returns **404** (`web` still 200). Repointed the version to `bolls.life`'s `VULG` (same *Biblia Sacra juxta Vulgatam Clementinam*). Verified live: `1 Corinthians 2:5` returns Latin text. Removed the stale `clementine` entry from the bible-api translations doc comment.

> Note: the version key changed `clementine` → `vulg`. Users who had it selected will reset to default — but it was fully broken (404) regardless, and there is no separate translation-key field to preserve the old key.

## Verification
- Full test suite: **246 pass, 0 fail**
- Full monorepo build clean
- Obsidian package prettier + lint clean

## Related (no code here)
- #347 (Song of Songs) — appears already fixed; `--SongofSongs1` returns the whole chapter. Verify & close.
- #349 (translation selector) — enhancement, deferred.

Closes #355
Closes #342
Closes #357

https://claude.ai/code/session_01HvA9UdGcEyNyysyRVKKmmN