### PR TITLE
feat(plugin): Add Literal Word linking support

### DIFF
--- a/packages/obsidian-bible-reference/src/data/constants.ts
+++ b/packages/obsidian-bible-reference/src/data/constants.ts
@@ -63,6 +63,7 @@ export interface BibleReferencePluginSettings {
     | 'original'
     | 'blb'
     | 'biblegateway'
+    | 'literalword'
     | 'logos'
     | 'stepbible'
   bookNameLanguage?: BookNameLanguageEnum

--- a/packages/obsidian-bible-reference/src/ui/BibleReferenceSettingTab.ts
+++ b/packages/obsidian-bible-reference/src/ui/BibleReferenceSettingTab.ts
@@ -574,7 +574,7 @@ Obsidian Bible Reference  is proudly powered by
     const setting = new Setting(this.containerEl)
       .setName('Reference Link Source')
       .setDesc(
-        'Choose the source for verse reference links: Original (API provider), Blue Letter Bible, Bible Gateway, Logos, or StepBible'
+        'Choose the source for verse reference links: Original (API provider), Blue Letter Bible, Bible Gateway, Literal Word, Logos, or StepBible'
       )
     setting.setTooltip(
       'Select which service to use for generating verse reference links. This only applies when hyperlinking is enabled.'
@@ -583,6 +583,7 @@ Obsidian Bible Reference  is proudly powered by
       dropdown.addOption('original', 'Original (API Provider)')
       dropdown.addOption('blb', 'Blue Letter Bible (BLB)')
       dropdown.addOption('biblegateway', 'Bible Gateway')
+      dropdown.addOption('literalword', 'Literal Word')
       dropdown.addOption('logos', 'Logos')
       dropdown.addOption('stepbible', 'StepBible')
       dropdown.setValue(this.plugin.settings.sourceOfReference || 'original')
@@ -594,6 +595,7 @@ Obsidian Bible Reference  is proudly powered by
           | 'original'
           | 'blb'
           | 'biblegateway'
+          | 'literalword'
           | 'logos'
           | 'stepbible'
         this.updateLogosFallbackVisibility()

--- a/packages/obsidian-bible-reference/src/utils/referenceLiteralWordLinking.test.ts
+++ b/packages/obsidian-bible-reference/src/utils/referenceLiteralWordLinking.test.ts
@@ -1,0 +1,22 @@
+import { getLiteralWordUrl } from './referenceLiteralWordLinking'
+
+describe('referenceLiteralWordLinking', () => {
+  test('should generate correct Literal Word URL for single verse', () => {
+    const url = getLiteralWordUrl('esv', 'Genesis', 1, 1)
+    expect(url).toBe('https://app.literalword.com/esv/1/1/1')
+  })
+
+  test('should generate correct Literal Word URL for different translation', () => {
+    const url = getLiteralWordUrl('nasb', 'John', 3, 16)
+    expect(url).toBe('https://app.literalword.com/nasb/43/3/16')
+  })
+
+  test('should generate correct Literal Word URL for unknown translation', () => {
+    const url = getLiteralWordUrl('unknown', 'Mark', 1, 15)
+    expect(url).toBe('https://app.literalword.com/41/1/15')
+  })
+
+  test('should throw error for unknown book', () => {
+    expect(() => getLiteralWordUrl('esv', 'UnknownBook', 1, 1)).toThrow()
+  })
+})

--- a/packages/obsidian-bible-reference/src/utils/referenceLiteralWordLinking.ts
+++ b/packages/obsidian-bible-reference/src/utils/referenceLiteralWordLinking.ts
@@ -1,0 +1,112 @@
+// utils/referenceLiteralWordLinking.ts
+
+/**
+ * Mapping of standard book names to Literal Word abbreviations.
+ * Reference: https://app.literalword.com/deep-links
+ */
+export const literalWordBookAbbreviations: { [key: string]: string } = {
+  Genesis: '1',
+  Exodus: '2',
+  Leviticus: '3',
+  Numbers: '4',
+  Deuteronomy: '5',
+  Joshua: '6',
+  Judges: '7',
+  Ruth: '8',
+  '1 Samuel': '9',
+  '2 Samuel': '10',
+  '1 Kings': '11',
+  '2 Kings': '12',
+  '1 Chronicles': '13',
+  '2 Chronicles': '14',
+  Ezra: '15',
+  Nehemiah: '16',
+  Esther: '17',
+  Job: '18',
+  Psalms: '19',
+  Proverbs: '20',
+  Ecclesiastes: '21',
+  'Song of Solomon': '22',
+  Isaiah: '23',
+  Jeremiah: '24',
+  Lamentations: '25',
+  Ezekiel: '26',
+  Daniel: '27',
+  Hosea: '28',
+  Joel: '29',
+  Amos: '30',
+  Obadiah: '31',
+  Jonah: '32',
+  Micah: '33',
+  Nahum: '34',
+  Habakkuk: '35',
+  Zephaniah: '36',
+  Haggai: '37',
+  Zechariah: '38',
+  Malachi: '39',
+  Matthew: '40',
+  Mark: '41',
+  Luke: '42',
+  John: '43',
+  Acts: '44',
+  Romans: '45',
+  '1 Corinthians': '46',
+  '2 Corinthians': '47',
+  Galatians: '48',
+  Ephesians: '49',
+  Philippians: '50',
+  Colossians: '51',
+  '1 Thessalonians': '52',
+  '2 Thessalonians': '53',
+  '1 Timothy': '54',
+  '2 Timothy': '55',
+  Titus: '56',
+  Philemon: '57',
+  Hebrews: '58',
+  James: '59',
+  '1 Peter': '60',
+  '2 Peter': '61',
+  '1 John': '62',
+  '2 John': '63',
+  '3 John': '64',
+  Jude: '65',
+  Revelation: '66',
+}
+
+/**
+ * Mapping of plugin Bible version keys to Literal Word keywords.
+ * Reference: https://app.literalword.com/deep-links
+ */
+export const literalWordTranslationKeywords: { [key: string]: string } = {
+  nasb: 'nasb',
+  esv: 'esv',
+  lsb: 'lsb',
+  kjv: 'kjv',
+  nkjv: 'nkjv',
+}
+
+/**
+ * Generates a Literal Word app URL for a given verse reference.
+ * Reference: https://app.literalword.com/deep-links
+ */
+export function getLiteralWordUrl(
+  translation: string, // plugin translation key
+  bookName: string,
+  chapterNumber: number,
+  verseNumber: number
+): string {
+  const bookAbbr = literalWordBookAbbreviations[bookName]
+  if (!bookAbbr) {
+    throw new Error(`Literal Word abbreviation not found for ${bookName}`)
+  }
+
+  const translationAbbr = literalWordTranslationKeywords[translation]
+
+  if (translationAbbr) {
+    // https://app.literalword.com/<translation>/<book>/<chapter>[/<verse>]
+    return `https://app.literalword.com/${translationAbbr}/${bookAbbr}/${chapterNumber}/${verseNumber}`
+  }
+
+  // https://app.literalword.com/<book>/<chapter>[/<verse>]
+  return `https://app.literalword.com/${bookAbbr}/${chapterNumber}/${verseNumber}`
+}

--- a/packages/obsidian-bible-reference/src/verse/VerseSuggesting.ts
+++ b/packages/obsidian-bible-reference/src/verse/VerseSuggesting.ts
@@ -9,6 +9,7 @@ import { buildProvider } from '../provider/buildProvider'
 import { BaseBibleAPIProvider } from '../provider/BaseBibleAPIProvider'
 import { BaseVerseFormatter } from './BaseVerseFormatter'
 import { getBLBUrl } from '../utils/referenceBLBAltLinking'
+import { getLiteralWordUrl } from '../utils/referenceLiteralWordLinking'
 import {
   getLogosUrl,
   getLogosTranslation,
@@ -263,6 +264,13 @@ export class VerseSuggesting extends BaseVerseFormatter {
           chapterNumber,
           verseNumber,
           verseNumberEnd
+        ),
+      literalword: () =>
+        getLiteralWordUrl(
+          this.bibleVersion,
+          bookName,
+          chapterNumber,
+          verseNumber
         ),
       logos: () =>
         getLogosUrl(


### PR DESCRIPTION
(I have no affiliation with Literal Word, I'm just a big fan of the app and would love this toolkit to be able to generate the links that work with the app and website)

Literal Word (https://literalword.com/nasb/about/lw) offers a website and free, minimalist cross-platform apps (https://literalword.com/mobile) with several offline translations.

It supports a deep linking scheme (https://app.literalword.com/deep-links) that opens directly in the app on supported devices, and displays in-website otherwise.

This PR adds Literal Word to the options for linking schemes.

Here's a demo of it in action with a split-screen iPad with Obsidian on the left and Literal Word on the right:

https://github.com/user-attachments/assets/6a5358cb-bec5-43ae-bb92-3dc6e5646e0f

