### PR TITLE
feat: link-only reference insertion (#363)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 
 You can also get a "verse of the day" by typing `--vod`.
 
+To insert **just a link** to a passage instead of the verse text, enable **Link Only** in the settings, or run the **Insert Bible Reference Link** command. This never fetches, so it works offline.
+
 Polish translations are available as well, including **UBG** (Uwspółcześniona Biblia Gdańska) and **BG** (Biblia gdańska).
 
 > Read more about [How to use](https://github.com/tim-hub/obsidian-bible-reference/blob/master/docs/howto.md)

--- a/packages/obsidian-bible-reference/src/data/constants.ts
+++ b/packages/obsidian-bible-reference/src/data/constants.ts
@@ -42,6 +42,7 @@ export interface BibleReferencePluginSettings {
   collapsibleVerses?: boolean // this is binging to displayBibleIconPrefixAtHeader option
   collapsedByDefault?: boolean
   enableHyperlinking?: boolean
+  linkOnlyMode?: boolean // insert only a markdown link, never fetch the verse text
   showVerseTranslation?: boolean
   bookTagging?: boolean
   bookTaggingFormat: string
@@ -82,6 +83,7 @@ export const DEFAULT_SETTINGS: BibleReferencePluginSettings = {
   verseSegmentSeparatorFormat: BibleVerseSegmentSeparatorFormat.VerseSeparator,
   collapsibleVerses: false,
   enableHyperlinking: true,
+  linkOnlyMode: false,
   showVerseTranslation: true,
   bookTagging: false,
   bookTaggingFormat: '{{book}}',

--- a/packages/obsidian-bible-reference/src/main.ts
+++ b/packages/obsidian-bible-reference/src/main.ts
@@ -44,6 +44,7 @@ export default class BibleReferencePlugin extends Plugin {
 
     this.verseLookUpModal = new VerseLookupSuggestModal(this, this.settings)
     this.addVerseLookupCommand()
+    this.addVerseLinkCommand()
     this.addTranslationSwitchCommand()
     this.addRibbonButton()
 
@@ -144,6 +145,20 @@ export default class BibleReferencePlugin extends Plugin {
       name: 'Verse Lookup',
       callback: () => {
         this.verseLookUpModal.open()
+      },
+    })
+  }
+
+  /**
+   * Insert just a markdown link to the reference, regardless of the
+   * Link Only setting. Never fetches, so it works offline.
+   */
+  private addVerseLinkCommand(): void {
+    this.addCommand({
+      id: 'obr-insert-reference-link',
+      name: 'Insert Bible Reference Link (no verse text)',
+      callback: () => {
+        new VerseLookupSuggestModal(this, this.settings, true).open()
       },
     })
   }

--- a/packages/obsidian-bible-reference/src/provider/BollyLifeProvider.ts
+++ b/packages/obsidian-bible-reference/src/provider/BollyLifeProvider.ts
@@ -17,7 +17,9 @@ export class BollyLifeProvider extends BaseBibleAPIProvider {
   }
 
   public getOriginalVerseReferenceLink(): string {
-    return this._currentQueryUrl.replace('/get-text', '')
+    // _currentQueryUrl is only set by buildRequestURL during a fetch; link-only
+    // insertion never fetches, so '' lets the caller fall back to Bible Gateway.
+    return this._currentQueryUrl?.replace('/get-text', '') ?? ''
   }
 
   public buildRequestURL(

--- a/packages/obsidian-bible-reference/src/suggesetor/VerseEditorSuggester.ts
+++ b/packages/obsidian-bible-reference/src/suggesetor/VerseEditorSuggester.ts
@@ -34,6 +34,10 @@ export class VerseEditorSuggester extends EditorSuggest<VerseSuggesting> {
     this.settings = settings
   }
 
+  private get isLinkOnly(): boolean {
+    return !!this.settings?.linkOnlyMode
+  }
+
   private getBookVerseAndTranslation(queryContent: string) {
     let bookVerseQuery = queryContent
     let translationQuery = ''
@@ -119,19 +123,22 @@ export class VerseEditorSuggester extends EditorSuggest<VerseSuggesting> {
     const suggestions = await getSuggestionsFromQuery(
       bookVerseQuery,
       this.settings,
-      translationQuery
+      translationQuery,
+      this.isLinkOnly
     )
     return suggestions
   }
 
   renderSuggestion(suggestion: VerseSuggesting, el: HTMLElement): void {
-    suggestion.renderSuggestion(el)
+    suggestion.renderSuggestion(el, this.isLinkOnly)
   }
 
   selectSuggestion(suggestion: VerseSuggesting): void {
     if (this.context) {
       this.context.editor.replaceRange(
-        suggestion.allFormattedContent,
+        this.isLinkOnly
+          ? suggestion.linkOnlyContent
+          : suggestion.allFormattedContent,
         this.context.start,
         this.context.end
       )

--- a/packages/obsidian-bible-reference/src/suggesetor/VerseLookupSuggestModal.ts
+++ b/packages/obsidian-bible-reference/src/suggesetor/VerseLookupSuggestModal.ts
@@ -10,17 +10,23 @@ export class VerseLookupSuggestModal extends SuggestModal<VerseSuggesting> {
 
   constructor(
     plugin: BibleReferencePlugin,
-    settings: BibleReferencePluginSettings
+    settings: BibleReferencePluginSettings,
+    private forceLinkOnly = false
   ) {
     super(plugin.app)
     this.settings = settings
     this.setInstructions([
       {
         command: '',
-        purpose:
-          'Select verses to insert, ex: John1:1-3  ·  John1:a for a whole chapter',
+        purpose: forceLinkOnly
+          ? 'Select a reference to insert as a link, ex: John1:1-3  ·  John1:a for a whole chapter'
+          : 'Select verses to insert, ex: John1:1-3  ·  John1:a for a whole chapter',
       },
     ])
+  }
+
+  private get isLinkOnly(): boolean {
+    return this.forceLinkOnly || !!this.settings?.linkOnlyMode
   }
 
   public onOpen() {
@@ -34,13 +40,18 @@ export class VerseLookupSuggestModal extends SuggestModal<VerseSuggesting> {
     }
     if (match) {
       console.debug('trigger on', query)
-      return getSuggestionsFromQuery(`${query}`, this.settings)
+      return getSuggestionsFromQuery(
+        `${query}`,
+        this.settings,
+        undefined,
+        this.isLinkOnly
+      )
     }
     return []
   }
 
   renderSuggestion(suggestion: VerseSuggesting, el: HTMLElement) {
-    suggestion.renderSuggestion(el)
+    suggestion.renderSuggestion(el, this.isLinkOnly)
   }
 
   onChooseSuggestion(item: VerseSuggesting, evt: MouseEvent | KeyboardEvent) {
@@ -48,6 +59,9 @@ export class VerseLookupSuggestModal extends SuggestModal<VerseSuggesting> {
     if (!editor) {
       return
     }
-    editor.replaceRange(item.allFormattedContent, editor.getCursor())
+    editor.replaceRange(
+      this.isLinkOnly ? item.linkOnlyContent : item.allFormattedContent,
+      editor.getCursor()
+    )
   }
 }

--- a/packages/obsidian-bible-reference/src/ui/BibleReferenceSettingTab.ts
+++ b/packages/obsidian-bible-reference/src/ui/BibleReferenceSettingTab.ts
@@ -89,6 +89,7 @@ export class BibleReferenceSettingTab extends PluginSettingTab {
     // 2 options for reference
     this.setUpShowVerseTranslationOptions()
     this.setUpHyperlinkingOptions()
+    this.setUpLinkOnlyOptions()
     this.setUpSourceOfReferenceOptions()
     this.setUpVerseFormatOptions()
     this.setUpVerseNumberFormatOptions()
@@ -570,6 +571,26 @@ Obsidian Bible Reference  is proudly powered by
     })
   }
 
+  private setUpLinkOnlyOptions(): void {
+    const setting = new Setting(this.containerEl)
+      .setName('Link Only')
+      .setDesc(
+        'Insert only a markdown link to the reference, without fetching the verse text (works offline).'
+      )
+    setting.setTooltip(
+      'For users who read passages in a dedicated Bible app. The Verse Of The Day is not affected.'
+    )
+    setting.addToggle((toggle) => {
+      toggle
+        .setValue(!!this.plugin.settings?.linkOnlyMode)
+        .onChange(async (value) => {
+          this.plugin.settings.linkOnlyMode = value
+          await this.plugin.saveSettings()
+          pluginEvent.trigger('bible-reference:settings:re-render', [])
+        })
+    })
+  }
+
   private setUpSourceOfReferenceOptions(): void {
     const setting = new Setting(this.containerEl)
       .setName('Reference Link Source')
@@ -577,7 +598,7 @@ Obsidian Bible Reference  is proudly powered by
         'Choose the source for verse reference links: Original (API provider), Blue Letter Bible, Bible Gateway, Literal Word, Logos, or StepBible'
       )
     setting.setTooltip(
-      'Select which service to use for generating verse reference links. This only applies when hyperlinking is enabled.'
+      'Select which service to use for generating verse reference links. This only applies when hyperlinking or Link Only is enabled.'
     )
     setting.addDropdown((dropdown: DropdownComponent) => {
       dropdown.addOption('original', 'Original (API Provider)')
@@ -587,7 +608,10 @@ Obsidian Bible Reference  is proudly powered by
       dropdown.addOption('logos', 'Logos')
       dropdown.addOption('stepbible', 'StepBible')
       dropdown.setValue(this.plugin.settings.sourceOfReference || 'original')
-      if (!this.plugin.settings?.enableHyperlinking) {
+      if (
+        !this.plugin.settings?.enableHyperlinking &&
+        !this.plugin.settings?.linkOnlyMode
+      ) {
         dropdown.setDisabled(true)
       }
       dropdown.onChange(async (value) => {

--- a/packages/obsidian-bible-reference/src/utils/getSuggestionsFromQuery.test.ts
+++ b/packages/obsidian-bible-reference/src/utils/getSuggestionsFromQuery.test.ts
@@ -1,0 +1,40 @@
+import { getSuggestionsFromQuery } from './getSuggestionsFromQuery'
+import { DEFAULT_SETTINGS } from '../data/constants'
+
+const settings = { ...DEFAULT_SETTINGS, bibleVersion: 'kjv' }
+
+describe('getSuggestionsFromQuery with linkOnly', () => {
+  it('returns one suggestion without fetching the verse text', async () => {
+    const suggestions = await getSuggestionsFromQuery(
+      'John 3:16',
+      settings,
+      undefined,
+      true
+    )
+    expect(suggestions).toHaveLength(1)
+    expect(suggestions[0].linkOnlyContent).toBe(
+      '[John 3:16 - KJV](https://www.biblegateway.com/passage/?search=John+3:16&version=kjv)'
+    )
+    expect(suggestions[0].bodyContent).toBe('')
+  })
+
+  it('returns no suggestion for an invalid reference', async () => {
+    const suggestions = await getSuggestionsFromQuery(
+      'Hebrews 10:1-9:14',
+      settings,
+      undefined,
+      true
+    )
+    expect(suggestions).toEqual([])
+  })
+
+  it('returns no suggestion when no book can be matched', async () => {
+    const suggestions = await getSuggestionsFromQuery(
+      '3:16',
+      settings,
+      undefined,
+      true
+    )
+    expect(suggestions).toEqual([])
+  })
+})

--- a/packages/obsidian-bible-reference/src/utils/getSuggestionsFromQuery.ts
+++ b/packages/obsidian-bible-reference/src/utils/getSuggestionsFromQuery.ts
@@ -9,11 +9,14 @@ import { splitBibleReference } from './splitBibleReference'
  * Get suggestions from string query
  * @param queryWithoutPrefix without the prefix trigger
  * @param settings
+ * @param translation
+ * @param linkOnly skip the verse text fetch, the caller only needs a link
  */
 export const getSuggestionsFromQuery = async (
   queryWithoutPrefix: string,
   settings: BibleReferencePluginSettings,
-  translation?: string
+  translation?: string,
+  linkOnly = false
 ): Promise<VerseSuggesting[]> => {
   console.debug(
     'get suggestion for query ',
@@ -82,6 +85,8 @@ export const getSuggestionsFromQuery = async (
     suggestingVerse,
     settings
   )
-  await suggestingVerse.fetchAndSetVersesText()
+  if (!linkOnly) {
+    await suggestingVerse.fetchAndSetVersesText()
+  }
   return [suggestingVerse]
 }

--- a/packages/obsidian-bible-reference/src/verse/VerseSuggesting.linkOnly.test.ts
+++ b/packages/obsidian-bible-reference/src/verse/VerseSuggesting.linkOnly.test.ts
@@ -1,0 +1,99 @@
+import { VerseSuggesting } from './VerseSuggesting'
+import {
+  BibleReferencePluginSettings,
+  DEFAULT_SETTINGS,
+} from '../data/constants'
+import {
+  getReferenceHead,
+  splitBibleReference,
+} from '../utils/splitBibleReference'
+
+const buildSuggesting = (
+  query: string,
+  overrides: Partial<BibleReferencePluginSettings> = {}
+): VerseSuggesting => {
+  const settings = { ...DEFAULT_SETTINGS, ...overrides }
+  const reference = splitBibleReference(query)
+  return new VerseSuggesting(
+    settings,
+    reference.bookName,
+    reference.chapterNumber,
+    reference.verseNumber,
+    reference.verseNumberEnd,
+    reference.chapterNumberEnd,
+    reference.verseNumberEndChapter,
+    reference.ranges
+  )
+}
+
+describe('VerseSuggesting.linkOnlyContent', () => {
+  it('renders a bare markdown link with the default settings', () => {
+    const suggesting = buildSuggesting('John 3:16', { bibleVersion: 'kjv' })
+    expect(suggesting.linkOnlyContent).toBe(
+      '[John 3:16 - KJV](https://www.biblegateway.com/passage/?search=John+3:16&version=kjv)'
+    )
+  })
+
+  it('contains no callout, tag or leading whitespace decoration', () => {
+    const content = buildSuggesting('John 3:16').linkOnlyContent
+    expect(content).not.toContain('> ')
+    expect(content).not.toContain('[!bible]')
+    expect(content).not.toContain('%%')
+    expect(content).toBe(content.trim())
+  })
+
+  it('omits the translation suffix when showVerseTranslation is off', () => {
+    const content = buildSuggesting('John 3:16', {
+      bibleVersion: 'kjv',
+      showVerseTranslation: false,
+    }).linkOnlyContent
+    expect(content.startsWith('[John 3:16]')).toBe(true)
+    expect(content).not.toContain(' - KJV')
+  })
+
+  it('still emits a link when hyperlinking is disabled', () => {
+    const content = buildSuggesting('John 3:16', {
+      enableHyperlinking: false,
+    }).linkOnlyContent
+    expect(content).toMatch(/^\[.+]\(https:\/\/.+\)$/)
+  })
+
+  it('labels a cross-chapter reference with getReferenceHead', () => {
+    const suggesting = buildSuggesting('Hebrews 9:1-10:14', {
+      bibleVersion: 'kjv',
+    })
+    const head = getReferenceHead(suggesting.verseReference)
+    expect(suggesting.linkOnlyContent.startsWith(`[${head} - KJV](`)).toBe(true)
+  })
+
+  it('labels a multi-segment reference with getReferenceHead', () => {
+    const suggesting = buildSuggesting('John 3:16,18', { bibleVersion: 'kjv' })
+    const head = getReferenceHead(suggesting.verseReference)
+    expect(suggesting.linkOnlyContent.startsWith(`[${head} - KJV](`)).toBe(true)
+  })
+
+  it('falls back to Bible Gateway for the original source without a fetch', () => {
+    // 'bbe' is a bollsLife version - its original link is only known after a
+    // fetch, which link-only never does.
+    const suggesting = buildSuggesting('John 3:16', {
+      bibleVersion: 'bbe',
+      sourceOfReference: 'original',
+    })
+    expect(() => suggesting.linkOnlyContent).not.toThrow()
+    expect(suggesting.linkOnlyContent).toContain(
+      'https://www.biblegateway.com/passage/'
+    )
+  })
+
+  it('falls back to Bible Gateway when the blb builder throws', () => {
+    const suggesting = buildSuggesting('John 3:16', {
+      bibleVersion: 'kjv',
+      sourceOfReference: 'blb',
+    })
+    // @ts-ignore - force an unmapped book name past the parser
+    suggesting.verseReference.bookName = 'UnknownBook'
+    expect(suggesting.linkOnlyContent).toContain(
+      'https://www.biblegateway.com/passage/'
+    )
+  })
+})

--- a/packages/obsidian-bible-reference/src/verse/VerseSuggesting.ts
+++ b/packages/obsidian-bible-reference/src/verse/VerseSuggesting.ts
@@ -98,10 +98,20 @@ export class VerseSuggesting extends BaseVerseFormatter {
   /**
    * Render for use in editor/modal suggest
    */
-  public renderSuggestion(el: HTMLElement) {
+  public renderSuggestion(el: HTMLElement, linkOnly = false) {
     const outer = el.createDiv({ cls: 'obr-suggester-container' })
     // @ts-ignore
-    outer.createDiv({ cls: 'obr-shortcode' }).setText(this.bodyContent)
+    outer
+      .createDiv({ cls: 'obr-shortcode' })
+      .setText(linkOnly ? this.linkOnlyContent : this.bodyContent)
+  }
+
+  /**
+   * A bare markdown link to the reference - no verse text, no callout, no tags.
+   * Never fetches, so it works offline.
+   */
+  public get linkOnlyContent(): string {
+    return `[${this.getReferenceLabel()}](${this.getUrlForReference()})`
   }
 
   public async fetchAndSetVersesText(): Promise<void> {
@@ -304,14 +314,20 @@ export class VerseSuggesting extends BaseVerseFormatter {
     }
   }
 
-  protected getVerseReferenceLink(): string {
-    // For cross-chapter and multi-segment references, use centralized getReferenceHead
+  /**
+   * The human readable reference, ex. `John 3:16 - KJV`
+   * For cross-chapter and multi-segment references, use centralized getReferenceHead
+   */
+  private getReferenceLabel(): string {
     const head = getReferenceHead(this.verseReference)
-
     const version = this.settings?.showVerseTranslation
       ? ` - ${this.bibleVersion.toUpperCase()}`
       : ''
-    const label = `${head}${version}`
+    return `${head}${version}`
+  }
+
+  protected getVerseReferenceLink(): string {
+    const label = this.getReferenceLabel()
 
     // keep the original leading space that the previous implementation returned
     const leading = ' '


### PR DESCRIPTION
Closes #363. Relates to #289 / discussion #288.

> **Scope note:** this PR originally also added a Literal Word link source. That is dropped — #364 does the same thing and landed first. This PR is now purely the link-only feature.

## What

Users of dedicated Bible apps (Literal Word, Logos) wanted the plugin to insert **just a link** to a passage — no fetch, no verse text, no callout. As a side effect, reference insertion now works fully offline.

Two ways in:

- a **Link Only** toggle in Settings → Verses Rendering
- an **Insert Bible Reference Link (no verse text)** command, which ignores the toggle

Both cover the `++`/`--` editor trigger and the Verse Lookup modal. **Verse Of The Day is unchanged.**

Output looks like `[John 3:16 - ESV](https://…)`.

## How

The URL builders were already pure and network-free, so this is mostly *not* calling the fetch and *not* routing output through the callout formatter.

- `VerseSuggesting.linkOnlyContent` is a **sibling** of `allFormattedContent`, not a variant of it — `BaseVerseFormatter.head` hardcodes `> ` and `bottom` appends `%%` tags, neither of which belongs in an inline link. `BaseVerseFormatter` is untouched.
- The label is extracted from `getVerseReferenceLink()` and the URL comes from `getUrlForReference()` verbatim, so every existing fallback path (a throwing builder → Bible Gateway, unknown source → Bible Gateway) is inherited for free.
- `getSuggestionsFromQuery` takes a trailing `linkOnly = false` that gates `fetchAndSetVersesText()`. Everything above it — book match, localization, `splitBibleReference` — is already pure, so link-only inherits identical parsing, validation and localization. Invalid refs still return `[]`. The `PluginAPI` and VOD callers needed no edit.

### Blocker fixed

`BollyLifeProvider.getOriginalVerseReferenceLink()` read `_currentQueryUrl`, which is only set *during* a fetch, and the `'original'` branch sits outside the try/catch in `getUrlForReference()`. With no fetch that threw a `TypeError`. 64 bundled versions use `bollsLife`, so this was the common case. Now returns `''`, which is falsy and hits the existing Bible Gateway fallback — no new branch.

## Decisions worth a look

- **`enableHyperlinking: false` + link-only → link-only wins.** The whole output *is* the link, so honoring the toggle would make the feature a no-op. Locked in by a test.
- **Reference Link Source** dropdown is now enabled when *either* hyperlinking or Link Only is on — otherwise the source would be unselectable in exactly the mode that needs it.
- Trigger prefixes unchanged — `++` stays a documented alias, not repurposed.

## Tests

`bun test` → **204 pass, 0 fail**. `tsc --noEmit` clean, `bun run build` succeeds.

11 new tests across 2 files, all pure-function:

- `VerseSuggesting.linkOnly.test.ts` — exact output; regression guard that no `> `, `[!bible]`, `%%` or leading space leaks in; `showVerseTranslation: false`; hyperlinking-off still links; cross-chapter and multi-segment labels; `'original'` on a `bollsLife` version does not throw; a throwing `blb` builder falls back
- `getSuggestionsFromQuery.test.ts` — network-free with `linkOnly: true`; invalid ref → `[]`

The suggester / modal / settings wiring is not covered by tests and **still needs manual verification with the network disabled**.

## Known limitations (pre-existing, documented not fixed)

- `getUrlForReference()` encodes only the **first** range, so `John 3:16,18` links to `16`. More visible now that the link is the whole output.
- Bare chapters (`++John3`) still produce no suggestion — `hasExplicitVerse` gates it. Arguably desirable for link-only, but out of scope.

`docs/howto.md` is a wiki redirect; the wiki page needs the same README line added outside this repo.

https://claude.ai/code/session_01VuobNSDExNbUJFrzNMPKbN
