### PR TITLE
fix: match the inline version key case insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@
 > A chapter on its own (`--John1`) does not suggest anything - it is treated as a
 > reference you are still typing, so add `:1` or `:a` to finish it.
 
+> To pull a reference from another translation, add `@` and the version key:
+> `--John1:1@esv`. Keys are the ones listed under **Default Bible Version** in the
+> settings, and they are not case sensitive. The version you name is kept for later
+> lookups too, so it also switches the default.
+
 You can also get a "verse of the day" by typing `--vod`.
 
 To insert **just a link** to a passage instead of the verse text, enable **Link Only** in the settings, or run the **Insert Bible Reference Link** command. This never fetches, so it works offline.

--- a/packages/obsidian-bible-reference/src/suggesetor/VerseEditorSuggester.test.ts
+++ b/packages/obsidian-bible-reference/src/suggesetor/VerseEditorSuggester.test.ts
@@ -1,15 +1,14 @@
 import { VerseEditorSuggester } from './VerseEditorSuggester'
 import { DEFAULT_SETTINGS } from '../data/constants'
 
-const newSuggester = () =>
-  new VerseEditorSuggester(
-    {
-      app: {},
-      settings: { ...DEFAULT_SETTINGS },
-      saveSettings: () => {},
-    } as never,
-    DEFAULT_SETTINGS
-  )
+const newPlugin = () => ({
+  app: {},
+  settings: { ...DEFAULT_SETTINGS },
+  saveSettings: () => {},
+})
+
+const newSuggester = (plugin = newPlugin()) =>
+  new VerseEditorSuggester(plugin as never, DEFAULT_SETTINGS)
 
 const triggerOn = (line: string, cursorCh: number = line.length) =>
   newSuggester().onTrigger(
@@ -94,5 +93,45 @@ describe('VerseEditorSuggester.onTrigger', () => {
     '--123 John 1:1',
   ])('does not trigger on %s', (line) => {
     expect(triggerOn(line)).toBeNull()
+  })
+})
+
+describe('VerseEditorSuggester inline version', () => {
+  const triggerWithPlugin = (line: string) => {
+    const plugin = newPlugin()
+    const info = newSuggester(plugin).onTrigger(
+      { line: 0, ch: line.length },
+      { getLine: () => line } as never,
+      null as never
+    )
+    return { info, plugin }
+  }
+
+  // "@" names the version, and the key is written in either case.
+  test.each([
+    ['--John 3:16@esv', 'John 3:16@esv', 'esv'],
+    ['--John 3:16@ESV', 'John 3:16@esv', 'esv'],
+    ['--john3:16-17@kjv', 'john3:16-17@kjv', 'kjv'],
+    ['--john3:16-17@KJV', 'john3:16-17@kjv', 'kjv'],
+    // A version key with a dash of its own must survive whole.
+    ['--John 3:16@oeb-cw', 'John 3:16@oeb-cw', 'oeb-cw'],
+  ])('%s picks the version', (line, query, version) => {
+    const { info, plugin } = triggerWithPlugin(line)
+    expect(info?.query).toBe(query)
+    expect(plugin.settings.bibleVersion).toBe(version)
+  })
+
+  // The dash stays the range separator, it never names a version.
+  test.each(['--John 3:16-18', '--Hebrews 9:1-10:14', '--John 3:a'])(
+    '%s leaves the version alone',
+    (line) => {
+      const { info, plugin } = triggerWithPlugin(line)
+      expect(info).not.toBeNull()
+      expect(plugin.settings.bibleVersion).toBe(DEFAULT_SETTINGS.bibleVersion)
+    }
+  )
+
+  test('the dash form is not a version suffix', () => {
+    expect(triggerOn('--John 3:16-esv')).toBeNull()
   })
 })

--- a/packages/obsidian-bible-reference/src/utils/regs.ts
+++ b/packages/obsidian-bible-reference/src/utils/regs.ts
@@ -85,12 +85,13 @@ export const BOOK_VERSE_REG = new RegExp(
 
 export const BOOK_REG = new RegExp(`${BOOK_ORDINAL}\\s*(${BOOK_NAME})`, 'isu')
 
+/**
+ * The version key of the inline suffix a reference can carry, "John 3:16@esv".
+ * The separator is "@" and nothing else: the dash is already the verse range
+ * separator in "John 3:16-17", so it cannot also introduce a version without
+ * the parser guessing at which one was meant.
+ */
 export const TRANSLATION_VERSION_KEY_REG = /^[a-zA-Z]+-?[a-zA-Z0-9]*$/isu
-
-export const BOOK_VERSE_WITH_TRANSLATION_REG = new RegExp(
-  `(${BOOK_VERSE_REG.source})[@-](${TRANSLATION_VERSION_KEY_REG.source.slice(1, -1)})`,
-  'isu'
-) // todo maybe this is a better option
 
 // export const BOOK_REG = /[123]*\s*[A-Z\[\\\]^_`a-z]{2,}/
 

--- a/packages/obsidian-bible-reference/src/utils/versionSelectionMatch.test.ts
+++ b/packages/obsidian-bible-reference/src/utils/versionSelectionMatch.test.ts
@@ -15,6 +15,11 @@ test('test versionSelection match oeb-cw', () => {
   expect(result).toBe('oeb-cw')
 })
 
+test('test versionSelection folds the key to lowercase', () => {
+  expect(versionSelectionMatch('ESV')).toBe('esv')
+  expect(versionSelectionMatch('OEB-CW')).toBe('oeb-cw')
+})
+
 test('test versionSelection match not oeb--cw', () => {
   const result = versionSelectionMatch('oeb--cw')
   expect(result).toBe('')

--- a/packages/obsidian-bible-reference/src/utils/versionSelectionMatch.ts
+++ b/packages/obsidian-bible-reference/src/utils/versionSelectionMatch.ts
@@ -2,6 +2,11 @@ import { TRANSLATION_VERSION_KEY_REG } from './regs'
 
 /**
  * check if the given string contains a verseNumber, and return the verseNumber if it does
+ *
+ * Version keys are lowercase in the collection, so the match is folded to
+ * lowercase here. Users write "ESV" as often as "esv", and every caller
+ * downstream compares against the key or stores it in the settings.
+ *
  * @param verseWithVersionAtEnd without the prefix trigger --
  * @returns string the same string if it match
  */
@@ -16,6 +21,6 @@ export const versionSelectionMatch = (
   if (!matchResults) {
     return ''
   } else {
-    return matchResults[0]
+    return matchResults[0].toLowerCase()
   }
 }


### PR DESCRIPTION
Closes #370

Reported in [discussion #204](https://github.com/tim-hub/obsidian-bible-reference/discussions/204#discussioncomment-17925027): `--John3:16-ESV` and `--john3:16-17-KJV` show no suggestion at all.

## What was wrong

Two things, and only one of them is a bug.

**The version key was matched case sensitively.** Every key in the collection is lowercase, and `getBibleVersion` does an exact `===` with a silent fallback to the default. So `--John 3:16@ESV` quietly gave you `bbe` rather than the ESV, and the `getBibleVersion(key).key == key` guard in `onTrigger` then left the version untouched. That is the bug, and it is what this PR fixes.

**The dash form was never implemented.** `--John 3:16-esv` only ever worked in the reply on that discussion thread, not in the code. `@` has always been the separator. `BOOK_VERSE_WITH_TRANSLATION_REG` was a sketch of a dash-or-`@` version, carrying a `// todo`, imported nowhere.

## What changed

`versionSelectionMatch` folds the matched key to lowercase, which is the form every key is stored in. Doing it there rather than in `getBibleVersion` also fixes the guard in `onTrigger`, which would otherwise still reject an uppercase key.

The dash form stays unsupported, deliberately. The dash is already the verse range separator in `--John 3:16-17`, and overloading it means guessing at which one the user meant. `BOOK_VERSE_WITH_TRANSLATION_REG` is dropped rather than left as a `// todo` for a direction we are not taking, and `TRANSLATION_VERSION_KEY_REG` now carries a note saying `@` is the only separator.

| input | book/verse | version |
| --- | --- | --- |
| `--John 3:16@esv` | `John 3:16` | `esv` |
| `--John 3:16@ESV` | `John 3:16` | `esv` |
| `--john3:16-17@KJV` | `john3:16-17` | `kjv` |
| `--John 3:16@oeb-cw` | `John 3:16` | `oeb-cw` |
| `--John 3:16-18` | `John 3:16-18` | unchanged |
| `--John 3:16-esv` | no suggestion | unchanged |

## Tests

`VerseEditorSuggester.test.ts` gains five cases through `onTrigger` asserting both the built query and the settings write, three range cases asserting the version is left alone, and one pinning the dash form as unsupported. `versionSelectionMatch.test.ts` covers the lowercase folding. Full suite 394 pass / 0 fail, `tsc -noEmit` clean.

## Docs

README documents the `@` syntax, which was not written down anywhere — the reason the wrong syntax circulated on the discussion thread in the first place. Corrected on the thread too.

## Left alone, worth a look separately

- Naming a version **switches your default permanently** (`VerseEditorSuggester.ts` writes `settings.bibleVersion`). The comment there says that is deliberate, but it is not what users assume in the discussion thread.
- An unknown key falls through silently — `--John3:16@xyz` shows the verse in the current version rather than telling you the key is not a version.
- `console.log` on the version-switch path.
- Building the workspace needs `bible-book-names-intl` then `bible-reference-toolkit` built first, or `bun test` fails on a missing module. Not in `docs/dev-setup.md`.

https://claude.ai/code/session_01JgmaLrQhTfafKtr4mbJkTg