### PR TITLE
fix: add Spanish book aliases

### DIFF
--- a/packages/bible-book-names-intl/src/data/translations/sp.json
+++ b/packages/bible-book-names-intl/src/data/translations/sp.json
@@ -2,22 +2,22 @@
   "language": "sp",
   "1": {
     "name": "Génesis",
-    "shortNames": ["Gen", "Gn"],
+    "shortNames": ["Gen", "Gn", "Genesis"],
     "startNumber": 0
   },
   "2": {
     "name": "Éxodo",
-    "shortNames": ["Exo", "Ex"],
+    "shortNames": ["Exo", "Ex", "Exodo"],
     "startNumber": 0
   },
   "3": {
     "name": "Levítico",
-    "shortNames": ["Lev", "Lv"],
+    "shortNames": ["Lev", "Lv", "Levitico"],
     "startNumber": 0
   },
   "4": {
     "name": "Números",
-    "shortNames": ["Num", "Nm"],
+    "shortNames": ["Num", "Nm", "Numeros"],
     "startNumber": 0
   },
   "5": {
@@ -27,7 +27,7 @@
   },
   "6": {
     "name": "Josué",
-    "shortNames": ["Jos"],
+    "shortNames": ["Jos", "Josue"],
     "startNumber": 0
   },
   "7": {
@@ -62,12 +62,12 @@
   },
   "13": {
     "name": "Crónicas",
-    "shortNames": ["Cro", "Cr"],
+    "shortNames": ["Cro", "Cr", "Cronicas"],
     "startNumber": 1
   },
   "14": {
     "name": "Crónicas",
-    "shortNames": ["Cro", "Cr"],
+    "shortNames": ["Cro", "Cr", "Cronicas"],
     "startNumber": 2
   },
   "15": {
@@ -77,7 +77,7 @@
   },
   "16": {
     "name": "Nehemías",
-    "shortNames": ["Neh"],
+    "shortNames": ["Neh", "Nehemias"],
     "startNumber": 0
   },
   "17": {
@@ -102,7 +102,7 @@
   },
   "21": {
     "name": "Eclesiastés",
-    "shortNames": ["Ecl", "Ec"],
+    "shortNames": ["Ecl", "Ec", "Eclesiastes"],
     "startNumber": 0
   },
   "22": {
@@ -112,12 +112,12 @@
   },
   "23": {
     "name": "Isaías",
-    "shortNames": ["Isa", "Is"],
+    "shortNames": ["Isa", "Is", "Isaias"],
     "startNumber": 0
   },
   "24": {
     "name": "Jeremías",
-    "shortNames": ["Jer", "Jr"],
+    "shortNames": ["Jer", "Jr", "Jeremias"],
     "startNumber": 0
   },
   "25": {
@@ -147,17 +147,17 @@
   },
   "30": {
     "name": "Amós",
-    "shortNames": ["Amo", "Am"],
+    "shortNames": ["Amo", "Am", "Amos"],
     "startNumber": 0
   },
   "31": {
     "name": "Abdías",
-    "shortNames": ["Abd"],
+    "shortNames": ["Abd", "Abdias"],
     "startNumber": 0
   },
   "32": {
     "name": "Jonás",
-    "shortNames": ["Jon"],
+    "shortNames": ["Jon", "Jonas"],
     "startNumber": 0
   },
   "33": {
@@ -167,7 +167,7 @@
   },
   "34": {
     "name": "Nahúm",
-    "shortNames": ["Nah"],
+    "shortNames": ["Nah", "Nahum"],
     "startNumber": 0
   },
   "35": {
@@ -186,8 +186,8 @@
     "startNumber": 0
   },
   "38": {
-    "name": "Zaccarías",
-    "shortNames": ["Zac"],
+    "name": "Zacarías",
+    "shortNames": ["Zac", "Zacarias"],
     "startNumber": 0
   },
   "39": {
@@ -217,7 +217,7 @@
   },
   "44": {
     "name": "Hechos de los Apóstoles",
-    "shortNames": ["Hch"],
+    "shortNames": ["Hch", "Hechos"],
     "startNumber": 0
   },
   "45": {
@@ -237,7 +237,7 @@
   },
   "48": {
     "name": "Gálatas",
-    "shortNames": ["Gal", "Ga"],
+    "shortNames": ["Gal", "Ga", "Galatas"],
     "startNumber": 0
   },
   "49": {
@@ -282,7 +282,7 @@
   },
   "57": {
     "name": "Filemón",
-    "shortNames": ["Flm"],
+    "shortNames": ["Flm", "Filemon"],
     "startNumber": 0
   },
   "58": {

--- a/packages/bible-reference-toolkit/src/test/reference.ext.test.ts
+++ b/packages/bible-reference-toolkit/src/test/reference.ext.test.ts
@@ -75,6 +75,34 @@ describe('Cross-language numbered book resolution (bookIdFromName)', () => {
   })
 })
 
+describe('Spanish aliases', () => {
+  test.each([
+    ['Genesis', 1],
+    ['Hechos', 44],
+    ['Zacarías', 38],
+    ['Zacarias', 38],
+    ['Exodo', 2],
+    ['Levitico', 3],
+    ['Numeros', 4],
+    ['Josue', 6],
+    ['1 Cronicas', 13],
+    ['2 Cronicas', 14],
+    ['Nehemias', 16],
+    ['Eclesiastes', 21],
+    ['Isaias', 23],
+    ['Jeremias', 24],
+    ['Amos', 30],
+    ['Abdias', 31],
+    ['Jonas', 32],
+    ['Nahum', 34],
+    ['Galatas', 48],
+    ['Filemon', 57],
+  ])('resolves %s through Spanish and cross-language lookups', (name, id) => {
+    expect(Reference.bookIdFromTranslationAndName('sp', name)).toBe(id)
+    expect(Reference.bookIdFromName(name)).toBe(id)
+  })
+})
+
 // The string constructor has always stripped the periods abbreviations are
 // written with ("Mk. 2"). The static lookups did not, so the plugin - which
 // calls them directly - could not resolve any dotted abbreviation.


### PR DESCRIPTION
## Summary

Improves Spanish book-name data without changing plugin parsing or manifest metadata.

- Corrects the canonical spelling `Zaccarías` to `Zacarías`.
- Adds the common `Hechos` alias for `Hechos de los Apóstoles`.
- Adds common accentless Spanish aliases such as `Exodo`, `1 Cronicas`, `Zacarias`, and `Filemon`.

`Cantares` was already included, so it is unchanged.

## Why

These aliases belong in `bible-book-names-intl`, where all supported book-name data is maintained, rather than in plugin-specific parsing logic.

## Testing

- Added regression cases for every new alias.
- Each alias is verified through both `bookIdFromTranslationAndName('sp', ...)` and the cross-language `bookIdFromName(...)` lookup.
- Ran `bun run build:packages`, the focused toolkit test suite (59 passing tests), Prettier, and ESLint.
